### PR TITLE
Legacy date entries requests and future proof requests

### DIFF
--- a/code/BlogTree.php
+++ b/code/BlogTree.php
@@ -162,9 +162,27 @@ class BlogTree extends Page {
 		}
 
 		if($date) {
-			if(strpos($date, '-')) {
-				$year = (int) substr($date, 0, strpos($date, '-'));
-				$month = (int) substr($date, strpos($date, '-') + 1);
+			/**
+			 * Some systems still use the / seperator for date presentation
+			 * In order to cater for them, I have implemented this quick way of using either one based on scenario
+			 * @author JA Clarke
+			 * @since 2011/05/05 SAST
+			 */
+			if( strpos($date, '-') ) $seperator = '-';
+			elseif( strpos($date, '/') ) $seperator = '/';
+			
+			if(isset($seperator) && !empty($seperator)) {
+			  /**
+			   * This is a better implementation of getting the $year and $month fields
+			   * substr() is fine, but it is major overhead
+			   * The 2 in the explode argument will tell it to only create 2 elements
+			   * i.e. in this instance the $year and $month fields respectively
+			   * @author JA Clarke
+			   * @since 2011/05/05 SAST
+			   */
+			  list($year,$month) = explode( $seperator, $date, 2);
+			  $year = (int)$year;
+			  $month = (int)$month;
 
 				if($year && $month) {
 					if(method_exists(DB::getConn(), 'formattedDatetimeClause')) {


### PR DESCRIPTION
A bit more code, but this solved a issue I was having on a SilverStripe installation where the dates produced by the archive widget were / delimited and not - delimited.
Added support for either scenario via this fix
