### PR TITLE
Use SS_Datetime instead of Datetime

### DIFF
--- a/code/BlogEntry.php
+++ b/code/BlogEntry.php
@@ -6,7 +6,7 @@
  */
 class BlogEntry extends Page {
 	static $db = array(
-		"Date" => "Datetime",
+		"Date" => "SS_Datetime",
 		"Author" => "Text",
 		"Tags" => "Text"
 	);


### PR DESCRIPTION
I tried to use my own Date format in a template using a custom Datetime-Class:

``` php
Object::useCustomClass('SS_Datetime', 'LocalDatetime');
```

This worked for comments but not for the Blog-Post. I found out, that `DataObject` uses `SS_Datetime` for `Created` and `LastEdited`.

When I changed `Datetime` to `SS_Datetime` in `BlogEntry`, my template worked right.
