### PR TITLE
FIXED: Missing hook to extensions updateCMSFields function

### DIFF
--- a/code/BlogEntry.php
+++ b/code/BlogEntry.php
@@ -78,6 +78,8 @@ class BlogEntry extends Page {
 				
 		$fields->addFieldToTab("Root.Main", new TextField("Tags", _t("BlogEntry.TS", "Tags (comma sep.)")),"Content");
 		
+		$this->extend('updateCMSFields', $fields);
+		
 		return $fields;
 	}
 	


### PR DESCRIPTION
For the reinstatement of BlogEntry getCMSFields extension hook, as removed earlier.

It did look a little odd hanging out in a Page subclass all by itself, but is required due to the call to parent::getCMSFields being done when extensions are disabled.

This commit fixes broken extensions.

Have a lovely day. :)
