### PR TITLE
Patch for Issue #42

### DIFF
--- a/code/BlogEntry.php
+++ b/code/BlogEntry.php
@@ -16,6 +16,8 @@ class BlogEntry extends Page {
 	static $can_be_root = false;
 	
 	static $icon = "blog/images/blogpage-file.png";
+
+	static $description = "An individual blog entry";
 		
 	static $has_one = array();
 	

--- a/code/BlogHolder.php
+++ b/code/BlogHolder.php
@@ -14,6 +14,8 @@
 class BlogHolder extends BlogTree implements PermissionProvider {
 	static $icon = "blog/images/blogholder-file.png";
 
+	static $description = "Displays Blog Entries";
+
 	static $db = array(
 		'TrackBacksEnabled' => 'Boolean',
 		'AllowCustomAuthors' => 'Boolean',

--- a/code/BlogTree.php
+++ b/code/BlogTree.php
@@ -12,6 +12,8 @@
 class BlogTree extends Page {
 
 	static $icon = "blog/images/blogtree-file.png";
+
+	static $description = "A grouping of blogs";
 	
 	// Default number of blog entries to show
 	static $default_entries_limit = 10;


### PR DESCRIPTION
For SilverStripe 3+, descriptions can be shown for each available page type
when pages are created.  This commit adds descriptions for the BlogEntry,
BlogHolder and BlogTree classes, as derived from comments within the code.
