### PR TITLE
Update code/BlogTree.php

### DIFF
--- a/code/BlogTree.php
+++ b/code/BlogTree.php
@@ -23,7 +23,7 @@ class BlogTree extends Page {
 	static $default_entries_limit = 10;
 	
 	static $db = array(
-		'Name' => 'Varchar',
+		'Name' => 'Varchar(255)',
 		'InheritSideBar' => 'Boolean',
 		'LandingPageFreshness' => 'Varchar',
 	);


### PR DESCRIPTION
Name of a blog could do with more space than default 50 characters (unless there is a particular good reason it is 50?).

Comes through as the RSS feed title, branding consistency may mean a longer than 50 char Blog name would be appropriate.

Example a blog name with a tagline...

"My Awesome Brand Blog - Servicing customers and good things like that."
