### PR TITLE
Fixed RSS Link, using 'rss' as $action param

### DIFF
--- a/code/widgets/SubscribeRSSWidget.php
+++ b/code/widgets/SubscribeRSSWidget.php
@@ -24,7 +24,7 @@ class SubscribeRSSWidget extends Widget {
 	function getRSSLink() {
 		Requirements::themedCSS('subscribersswidget');
 		$container = BlogTree::current();
-		if ($container) return $container->Link() . 'rss';
+		if ($container) return $container->Link('rss');
 	}
 }
 


### PR DESCRIPTION
Fixed RSS Link, using 'rss' as $action param for Link() method on BlogHolder.
This fixes the rss url when removing trailing slashes from page urls
