### PR TITLE
Tags with spaces will not properly locate BlogEntries

### DIFF
--- a/code/BlogTree.php
+++ b/code/BlogTree.php
@@ -322,7 +322,12 @@ class BlogTree_Controller extends Page_Controller {
 	 * @return String
 	 */
 	function SelectedTag() {
-		return ($this->request->latestParam('Action') == 'tag') ? Convert::raw2xml($this->request->latestParam('ID')) : '';
+		if ($this->request->latestParam('Action') == 'tag') {
+			$tag = $this->request->latestParam('ID');
+			$tag = urldecode($tag);
+			return Convert::raw2xml($tag);
+		}
+		return '';
 	}
 	
 	/**


### PR DESCRIPTION
Inside of 'code/BlogEntry.php' the method TagsCollection() 'urlencode's the tag before making it into a link.  Tags with spaces, and other special characters, will not return any BlogEntries from BlogTree::Entries().
