### PR TITLE
Fix Blog Dependency. Use Blog module without widgets module

### DIFF
--- a/code/widgets/BlogManagementWidget.php
+++ b/code/widgets/BlogManagementWidget.php
@@ -3,7 +3,7 @@
  * Blog Management Widget
  * @package blog
  */
-class BlogManagementWidget extends Widget implements PermissionProvider {
+class BlogManagementWidget extends Widget {
 	static $db = array();
 
 	static $has_one = array();


### PR DESCRIPTION
If BlogManagementWidget class implements PermissionProvider,
Blog module can't be used without Widgets Module.

In Admin, all Classes, that implements PermissionProvider are loaded,
but no widgets class (if the widgets module isn't installed)
