### PR TITLE
API 3.1 compatibility: Static configurable properties must be private and immutable

### DIFF
--- a/_config/trackback.yml
+++ b/_config/trackback.yml
@@ -1,0 +1,3 @@
+BlogEntry:
+  extensions:
+    - 'TrackBackDecorator'

--- a/code/BlogEntry.php
+++ b/code/BlogEntry.php
@@ -5,43 +5,33 @@
  * @package blog
  */
 class BlogEntry extends Page {
-	static $db = array(
+	private static $db = array(
 		"Date" => "SS_Datetime",
 		"Author" => "Text",
 		"Tags" => "Text"
 	);
 	
-	static $default_parent = 'BlogHolder';
+	private static $default_parent = 'BlogHolder';
 	
-	static $can_be_root = false;
+	private static $can_be_root = false;
 	
-	static $icon = "blog/images/blogpage-file.png";
+	private static $icon = "blog/images/blogpage-file.png";
 
-	static $description = "An individual blog entry";
+	private static $description = "An individual blog entry";
 	
-	static $singular_name = 'Blog Entry Page';
+	private static $singular_name = 'Blog Entry Page';
 	
-	static $plural_name = 'Blog Entry Pages';
-		
-	static $has_one = array();
+	private static $plural_name = 'Blog Entry Pages';
 	
-	static $has_many = array();
-	
-	static $many_many = array();
-	
-	static $belongs_many_many = array();
-	
-	static $defaults = array(
+	private static $defaults = array(
 		"ProvideComments" => true,
 		'ShowInMenus' => false
-	);
-	
-	static $extensions = array(
-		'TrackBackDecorator'
 	);
 		
 	/**
 	 * Is WYSIWYG editing allowed?
+	 * 
+	 * @todo Update to use SS3 Config
 	 * @var boolean
 	 */
 	static $allow_wysiwyg_editing = true;
@@ -248,7 +238,7 @@ class BlogEntry extends Page {
 
 class BlogEntry_Controller extends Page_Controller {
 	
-	static $allowed_actions = array(
+	private static $allowed_actions = array(
 		'index',
 		'trackbackping',
 		'unpublishPost',

--- a/code/BlogHolder.php
+++ b/code/BlogHolder.php
@@ -12,25 +12,25 @@
  * BlogHolders have a form on them for easy posting, and an owner that can post to them, BlogTrees don't
  */
 class BlogHolder extends BlogTree implements PermissionProvider {
-	static $icon = "blog/images/blogholder-file.png";
+	private static $icon = "blog/images/blogholder-file.png";
 
-	static $description = "Displays listings of blog entries";
+	private static $description = "Displays listings of blog entries";
 	
-	static $singular_name = 'Blog Holder Page';
+	private static $singular_name = 'Blog Holder Page';
 	
-	static $plural_name = 'Blog Holder Pages';
+	private static $plural_name = 'Blog Holder Pages';
 
-	static $db = array(
+	private static $db = array(
 		'TrackBacksEnabled' => 'Boolean',
 		'AllowCustomAuthors' => 'Boolean',
 		'ShowFullEntry' => 'Boolean', 
 	);
 
-	static $has_one = array(
+	private static $has_one = array(
 		'Owner' => 'Member',
 	);
 
-	static $allowed_children = array(
+	private static $allowed_children = array(
 		'BlogEntry'
 	);
 
@@ -167,7 +167,7 @@ class BlogHolder extends BlogTree implements PermissionProvider {
 }
 
 class BlogHolder_Controller extends BlogTree_Controller {
-	static $allowed_actions = array(
+	private static $allowed_actions = array(
 		'index',
 		'tag',
 		'date',
@@ -305,6 +305,3 @@ class BlogHolder_Controller extends BlogTree_Controller {
 		$this->redirect($this->Link());
 	}
 }
-
-
-?>

--- a/code/BlogTree.php
+++ b/code/BlogTree.php
@@ -11,33 +11,35 @@
 
 class BlogTree extends Page {
 
-	static $icon = "blog/images/blogtree-file.png";
+	private static $icon = "blog/images/blogtree-file.png";
 
-	static $description = "A grouping of blogs";
+	private static $description = "A grouping of blogs";
 	
-	static $singular_name = 'Blog Tree Page';
+	private static $singular_name = 'Blog Tree Page';
 	
-	static $plural_name = 'Blog Tree Pages';
+	private static $plural_name = 'Blog Tree Pages';
 	
-	// Default number of blog entries to show
+	/**
+	 * Default number of blog entries to show
+	 *
+	 * @todo Update to use SS Config
+	 * @var integer
+	 */
 	static $default_entries_limit = 10;
 	
-	static $db = array(
+	private static $db = array(
 		'Name' => 'Varchar(255)',
 		'InheritSideBar' => 'Boolean',
 		'LandingPageFreshness' => 'Varchar',
 	);
 	
-	static $defaults = array(
+	private static $defaults = array(
 		'InheritSideBar' => True
 	);
 	
-	static $has_one = array();
-
-	static $has_many = array();
-	
-	static $allowed_children = array(
-		'BlogTree', 'BlogHolder'
+	private static $allowed_children = array(
+		'BlogTree',
+		'BlogHolder'
 	);
 
 	
@@ -233,7 +235,7 @@ class BlogTree extends Page {
 
 class BlogTree_Controller extends Page_Controller {
 	
-	static $allowed_actions = array(
+	private static $allowed_actions = array(
 		'index',
 		'rss',
 		'tag',

--- a/code/MetaWeblogController.php
+++ b/code/MetaWeblogController.php
@@ -101,5 +101,3 @@ class MetaWeblogController extends Controller {
 		return array();
 	}
 }
-
-?>

--- a/code/TrackBackDecorator.php
+++ b/code/TrackBackDecorator.php
@@ -1,10 +1,14 @@
 <?php
+
 /**
  * Add trackback (receive and send) feature blog entry
- */ 
-
+ */
 class TrackBackDecorator extends DataExtension {
 	
+	/**
+	 * @todo Update to use SS Config and/or Injector definition
+	 * @var string
+	 */
 	static $trackback_server_class = 'TrackbackHTTPServer';
 	
 	// function extraStatics() {
@@ -16,7 +20,7 @@ class TrackBackDecorator extends DataExtension {
 	// 	);
 	// }
 
-	static $has_many = array(
+	private static $has_many = array(
 		'TrackBackURLs' => 'TrackBackURL',
 		'TrackBacks' => 'TrackBackPing'
 	);
@@ -157,5 +161,3 @@ class TrackbackHTTPServer {
 		return new SS_HTTPResponse($response, $statusCode);
 	}
 }
-
-?>

--- a/code/TrackBackPing.php
+++ b/code/TrackBackPing.php
@@ -1,7 +1,7 @@
 <?php
 
 class TrackBackPing extends DataObject {
-	static $db = array(
+	private static $db = array(
 		'Title' => 'Varchar',
 		'Excerpt' => 'Text',
 		// 2083 is URL-length limit for IE, AFAIK.
@@ -10,15 +10,7 @@ class TrackBackPing extends DataObject {
 		'BlogName' => 'Varchar'
 	);
 	
-	static $has_one = array(
+	private static $has_one = array(
 		'Page' => 'Page'
 	);
-	
-	static $has_many = array();
-	
-	static $many_many = array();
-	
-	static $belongs_many_many = array();
 }
-
-?>

--- a/code/TrackBackURL.php
+++ b/code/TrackBackURL.php
@@ -1,12 +1,13 @@
 <?php
+
 class TrackBackURL extends DataObject {
 	
-	static $db = array(
+	private static $db = array(
 		'URL' => 'Varchar(2048)',
 		'Pung' => 'Boolean(0)'
 	);
 	
-	static $has_one = array(
+	private static $has_one = array(
 		'BlogEntry' => 'BlogEntry'
 	);
 

--- a/code/import/TypoImport.php
+++ b/code/import/TypoImport.php
@@ -149,4 +149,3 @@ class TypoImport extends Controller {
 	} // end function
 
 } // end class
-?>

--- a/code/widgets/ArchiveWidget.php
+++ b/code/widgets/ArchiveWidget.php
@@ -6,27 +6,19 @@
  * @package blog
  */
 class ArchiveWidget extends Widget {
-	static $db = array(
+	private static $db = array(
 		'DisplayMode' => 'Varchar'
 	);
 	
-	static $has_one = array();
-	
-	static $has_many = array();
-	
-	static $many_many = array();
-	
-	static $belongs_many_many = array();
-	
-	static $defaults = array(
+	private static $defaults = array(
 		'DisplayMode' => 'month'
 	);
 	
-	static $title = 'Browse by Date';
+	private static $title = 'Browse by Date';
 
-	static $cmsTitle = 'Blog Archive';
+	private static $cmsTitle = 'Blog Archive';
 	
-	static $description = 'Show a list of months or years in which there are blog posts, and provide links to them.';
+	private static $description = 'Show a list of months or years in which there are blog posts, and provide links to them.';
 	
 	function getCMSFields() {
 		$fields = parent::getCMSFields(); 
@@ -107,5 +99,3 @@ class ArchiveWidget extends Widget {
 		return $results;
 	}	
 }
-
-?>

--- a/code/widgets/BlogManagementWidget.php
+++ b/code/widgets/BlogManagementWidget.php
@@ -4,21 +4,11 @@
  * @package blog
  */
 class BlogManagementWidget extends Widget implements PermissionProvider {
-	static $db = array();
-
-	static $has_one = array();
-
-	static $has_many = array();
-
-	static $many_many = array();
-
-	static $belongs_many_many = array();
-
-	static $defaults = array();
-
-	static $title = "Blog Management";
-	static $cmsTitle = "Blog Management";
-	static $description = "Provide a number of links useful for administering a blog. Only shown if the user is an admin.";
+	private static $title = "Blog Management";
+	
+	private static $cmsTitle = "Blog Management";
+	
+	private static $description = "Provide a number of links useful for administering a blog. Only shown if the user is an admin.";
 
 	function CommentText() {
 
@@ -64,4 +54,3 @@ class BlogManagementWidget_Controller extends Widget_Controller {
 		return ($container && $container->ClassName != "BlogTree") ? $container->Link('post') : false; 
 	}
 }
-?>

--- a/code/widgets/BlogTreeExtension.php
+++ b/code/widgets/BlogTreeExtension.php
@@ -2,6 +2,6 @@
 
 class BlogTreeExtension extends DataExtension {
 
-	static $has_one = array("SideBar" => "WidgetArea");
+	private static $has_one = array("SideBar" => "WidgetArea");
 
 }

--- a/code/widgets/RSSWidget.php
+++ b/code/widgets/RSSWidget.php
@@ -1,26 +1,20 @@
 <?php
 
 class RSSWidget extends Widget {
-	static $db = array(
+	private static $db = array(
 		"RSSTitle" => "Text",
 		"RssUrl" => "Text",
 		"NumberToShow" => "Int"
 	);
 	
-	static $has_one = array();
-	
-	static $has_many = array();
-	
-	static $many_many = array();
-	
-	static $belongs_many_many = array();
-	
-	static $defaults = array(
+	private static $defaults = array(
 		"NumberToShow" => 10,
 		"RSSTitle" => 'RSS Feed'
 	);
-	static $cmsTitle = "RSS Feed";
-	static $description = "Downloads another page's RSS feed and displays items in a list.";
+	
+	private static $cmsTitle = "RSS Feed";
+	
+	private static $description = "Downloads another page's RSS feed and displays items in a list.";
 	
 	/**
 	 * If the RssUrl is relative, convert it to absolute with the
@@ -92,5 +86,3 @@ class RSSWidget extends Widget {
 		}
 	}
 }
-
-?>

--- a/code/widgets/SubscribeRSSWidget.php
+++ b/code/widgets/SubscribeRSSWidget.php
@@ -9,11 +9,11 @@
  */
 class SubscribeRSSWidget extends Widget {
 	
-	static $title = 'Subscribe via RSS';
+	private static $title = 'Subscribe via RSS';
 	
-	static $cmsTitle = 'Subscribe via RSS widget';
+	private static $cmsTitle = 'Subscribe via RSS widget';
 	
-	static $description = 'Shows a link allowing a user to subscribe to this blog via RSS.';
+	private static $description = 'Shows a link allowing a user to subscribe to this blog via RSS.';
 
 	/**
 	 * Return an absolute URL based on the BlogHolder
@@ -27,5 +27,3 @@ class SubscribeRSSWidget extends Widget {
 		if ($container) return $container->Link('rss');
 	}
 }
-
-?>

--- a/code/widgets/TagCloudWidget.php
+++ b/code/widgets/TagCloudWidget.php
@@ -1,28 +1,22 @@
 <?php
 
 class TagCloudWidget extends Widget {
-	static $db = array(
+	
+	private static $db = array(
 		"Title" => "Varchar",
 		"Limit" => "Int",
 		"Sortby" => "Varchar"
 	);
 	
-	static $has_one = array();
-	
-	static $has_many = array();
-	
-	static $many_many = array();
-	
-	static $belongs_many_many = array();
-	
-	static $defaults = array(
+	private static $defaults = array(
 		"Title" => "Tag Cloud",
 		"Limit" => "0",
 		"Sortby" => "alphabet"
 	);
 	
-	static $cmsTitle = "Tag Cloud";
-	static $description = "Shows a tag cloud of tags on your blog.";
+	private static $cmsTitle = "Tag Cloud";
+	
+	private static $description = "Shows a tag cloud of tags on your blog.";
 
 	static $popularities = array( 'not-popular', 'not-very-popular', 'somewhat-popular', 'popular', 'very-popular', 'ultra-popular' );
 	
@@ -145,6 +139,3 @@ class TagCloudWidget extends Widget {
 		return true;
 	}
 }
-
-
-?>

--- a/tests/BlogHolderTest.php
+++ b/tests/BlogHolderTest.php
@@ -73,5 +73,3 @@ class BlogHolderTest extends SapphireTest {
 	}
 
 }
-
-?>

--- a/tests/BlogTreeTest.php
+++ b/tests/BlogTreeTest.php
@@ -104,5 +104,3 @@ class BlogTreeTest extends SapphireTest {
 		
 	}
 }
-
-?>

--- a/thirdparty/xmlrpc/xmlrpc.php
+++ b/thirdparty/xmlrpc/xmlrpc.php
@@ -3773,5 +3773,3 @@ xmlrpc_encode_entitites($this->errstr, $GLOBALS['xmlrpc_internalencoding'], $cha
 				return false;
 		}
 	}
-
-?>

--- a/thirdparty/xmlrpc/xmlrpc_wrappers.php
+++ b/thirdparty/xmlrpc/xmlrpc_wrappers.php
@@ -952,4 +952,3 @@
 		//$code .= "\$client->setDebug(\$debug);\n";
 		return $code;
 	}
-?>

--- a/thirdparty/xmlrpc/xmlrpcs.php
+++ b/thirdparty/xmlrpc/xmlrpcs.php
@@ -1243,4 +1243,3 @@
 			print $r->serialize();
 		}
 	}
-?>


### PR DESCRIPTION
Updated blog module to adhere to new rules around configuration. Static configurable properties (db, has_one, etc) are now private.

See http://doc.silverstripe.org/framework/en/3.1/changelogs/3.1.0#static-properties-are-immutable-and-private-you-must-use-config-api for the reasoning behind this.

I have also removed trailing ?>(followed by newline, whitespace, etc) from various files, and cleaned up some redundant code (empty has_ones, etc).

Also noted in the code are places where various static properties should be refactored out in favour of using the Silverstripe configuration system instead. For now the bare mimimum work has been done in order to make the module work in 3.1.

I will take a look at these once I have more time.
