### PR TITLE
API Moved "SideBar" widget relation to "widgets" module

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ or: mysite/blog/2007 would show blog entries for 2007
 
 See [:pagecomment](/pagecomment) for creating Askimet-protected comments for every page.
 
+## Widgets
+
+The module comes with a couple of default widgets, which rely on the "silverstripe/widgets"
+module being installed. Since widgets are based on database records and relations
+to pages, they need to be enabled through an `Extension` class in your `config.yml`:
+
+	:::yml
+	BlogTree:
+	  extensions:
+	    - WidgetPageExtension
+	BlogEntry:
+	  extensions:
+	    - WidgetPageExtension
+
+Alternatively, you can simply enable the extension on your `Page` records
+to have it available globally.
 
 ## Working with the theme
 

--- a/_config.php
+++ b/_config.php
@@ -1,3 +1,0 @@
-<?php
-
-if(class_exists('WidgetArea')) Object::add_extension('BlogTree','BlogTreeExtension');

--- a/code/BlogEntry.php
+++ b/code/BlogEntry.php
@@ -111,16 +111,6 @@ class BlogEntry extends Page {
 		}
 	}
 
-	/**
-	 * Get the sidebar from the BlogHolder.
-	 */
-	function SideBar() {
-		if(method_exists($this->Parent(), 'SideBar')) {
-			return $this->getParent()->SideBar();
-		}
-		
-	}
-	
 	function Content() {	
 		if(self::$allow_wysiwyg_editing) {
 			return $this->getField('Content');

--- a/code/BlogHolder.php
+++ b/code/BlogHolder.php
@@ -129,39 +129,45 @@ class BlogHolder extends BlogTree implements PermissionProvider {
 			$blogholder->Title = "Blog";
 			$blogholder->URLSegment = "blog";
 			$blogholder->Status = "Published";
+			$blogholder->write();
+			$blogholder->publish("Stage", "Live");
 
+			// Add default widgets to first found WidgetArea relationship
 			if(class_exists('WidgetArea')) {
-				$widgetarea = new WidgetArea();
-				$widgetarea->write();
+				foreach($this->has_one() as $name => $class) {
+					if(is_a($class, 'WidgetArea', true)) {
+						$relationName = "{$name}ID";
+						$widgetarea = new WidgetArea();
+						$widgetarea->write();
 
-				$blogholder->SideBarID = $widgetarea->ID;
-				$blogholder->write();
-				$blogholder->publish("Stage", "Live");
+						$blogholder->$relationName = $widgetarea->ID;
+						$blogholder->write();
+						$blogholder->publish("Stage", "Live");
 
-				$managementwidget = new BlogManagementWidget();
-				$managementwidget->ParentID = $widgetarea->ID;
-				$managementwidget->write();
+						$managementwidget = new BlogManagementWidget();
+						$managementwidget->ParentID = $widgetarea->ID;
+						$managementwidget->write();
 
-				$tagcloudwidget = new TagCloudWidget();
-				$tagcloudwidget->ParentID = $widgetarea->ID;
-				$tagcloudwidget->write();
+						$tagcloudwidget = new TagCloudWidget();
+						$tagcloudwidget->ParentID = $widgetarea->ID;
+						$tagcloudwidget->write();
 
-				$archivewidget = new ArchiveWidget();
-				$archivewidget->ParentID = $widgetarea->ID;
-				$archivewidget->write();
+						$archivewidget = new ArchiveWidget();
+						$archivewidget->ParentID = $widgetarea->ID;
+						$archivewidget->write();
 
-				$widgetarea->write();
-			} else {
-				$blogholder->write();
-				$blogholder->publish("Stage", "Live");
-			}	
-			
+						$widgetarea->write();	
+
+						break; // only apply to one
+					}
+				}
+			}
 
 			$blog = new BlogEntry();
 			$blog->Title = _t('BlogHolder.SUCTITLE', "SilverStripe blog module successfully installed");
 			$blog->URLSegment = 'sample-blog-entry';
 			$blog->Tags = _t('BlogHolder.SUCTAGS',"silverstripe, blog");
-			$blog->Content = _t('BlogHolder.SUCCONTENT',"<p>Congratulations, the SilverStripe blog module has been successfully installed. This blog entry can be safely deleted. You can configure aspects of your blog (such as the widgets displayed in the sidebar) in <a href=\"admin\">the CMS</a>.</p>");
+			$blog->Content = _t('BlogHolder.SUCCONTENT',"<p>Congratulations, the SilverStripe blog module has been successfully installed. This blog entry can be safely deleted. You can configure aspects of your blog in <a href=\"admin\">the CMS</a>.</p>");
 			$blog->Status = "Published";
 			$blog->ParentID = $blogholder->ID;
 			$blog->write();

--- a/code/BlogTree.php
+++ b/code/BlogTree.php
@@ -23,23 +23,12 @@ class BlogTree extends Page {
 	static $default_entries_limit = 10;
 	
 	static $db = array(
-		'InheritSideBar' => 'Boolean',
 		'LandingPageFreshness' => 'Varchar',
 	);
-	
-	static $defaults = array(
-		'InheritSideBar' => True
-	);
-	
-	static $has_one = array();
-
-	static $has_many = array();
 	
 	static $allowed_children = array(
 		'BlogTree', 'BlogHolder'
 	);
-
-	
 
 	/*
 	 * Finds the BlogTree object most related to the current page.
@@ -90,30 +79,8 @@ class BlogTree extends Page {
 		return $freshness;
 	}
 	
-	function SideBar() {
-		if($this->InheritSideBar && $this->getParent()) {
-			if (method_exists($this->getParent(), 'SideBar')) return $this->getParent()->SideBar();
-		}
-		
-		if($this->SideBarID){
-			return DataObject::get_by_id('WidgetArea', $this->SideBarID);
-			// @todo: This segfaults - investigate why then fix: return $this->getComponent('SideBar');
-		}
-	}
-	
 	/* ----------- CMS CONTROL -------------- */
 	
-	function getCMSFields() {
-		$fields = parent::getCMSFields();
-
- 		if(class_exists('WidgetArea')) {
- 			$fields->addFieldToTab("Root.Widgets", new CheckboxField("InheritSideBar", 'Inherit Sidebar From Parent'));
-			$fields->addFieldToTab("Root.Widgets", new WidgetAreaEditor("SideBar"));
- 		}
-		
-		return $fields;
-	}
-
 	function getSettingsFields() {
 		$fields = parent::getSettingsFields();
 

--- a/code/widgets/BlogTreeExtension.php
+++ b/code/widgets/BlogTreeExtension.php
@@ -1,7 +1,0 @@
-<?php
-
-class BlogTreeExtension extends DataExtension {
-
-	static $has_one = array("SideBar" => "WidgetArea");
-
-}

--- a/css/flickrwidget.css
+++ b/css/flickrwidget.css
@@ -1,3 +1,0 @@
-div.flickrwidget {
-	text-align: center;
-}

--- a/templates/Includes/BlogSideBar.ss
+++ b/templates/Includes/BlogSideBar.ss
@@ -1,3 +1,5 @@
-<div id="Sidebar" class="typography">
-	$SideBar
-</div>
+<% if SideBarView %>
+	<div id="Sidebar" class="typography">
+		$SideBarView
+	</div>
+<% end_if %>


### PR DESCRIPTION
Removed BlogTreeExtension in favour of the new WidgetPageExtension
in the "widgets module". Use the following code to update:

Object::add_extension('BlogTree', 'WidgetPageExtension');
Object::add_extension('BlogEntry', 'WidgetPageExtension');

The template placeholder has been renamed from $SideBar to
$SideBarView. In case you're overriding blog templates,
please adjust accordingly.

This change means that widgets can theoretically be applied
to individual blog entries as well, since they need the
"SideBar" relationship as well. In practice, this defaults
to "InheritSideBar" though, which pulls them from the BlogHolder as usual.

Relies on changes to widget, see https://github.com/silverstripe/silverstripe-widgets/commit/d83f0d2ae0ac0f96534ad752bc2b5531af8549b8

I've applied this to 0.6 instead of master in order to have the change compatible with SS 3.0, otherwise I feel that adoption of this stuff will be too slow if we make it 3.1 only
