### PR TITLE
Fix BlogHolder::BlogEntryForm() to call tinyMCE.init() if required

### DIFF
--- a/code/BlogHolder.php
+++ b/code/BlogHolder.php
@@ -235,6 +235,8 @@ class BlogHolder_Controller extends BlogTree_Controller {
 
 		if(BlogEntry::$allow_wysiwyg_editing) {
 			$contentfield = new HtmlEditorField("BlogPost", _t("BlogEntry.CN"));
+			// Force tinymce to init - otherwise Requirements::set_suffix_requirements() stops the init() call
+			Requirements::customScript("tinyMCE.init(ssTinyMceConfig);", "blog_post_tinyMCE_config");
 		} else {
 			$contentfield = new CompositeField(
 				new LiteralField("BBCodeHelper","<a id=\"BBCodeHint\" target='new'>"._t("BlogEntry.BBH")."</a><div class='clear'><!-- --></div>" ),


### PR DESCRIPTION
When Requirements::set_suffix_requirements(true) is set, the script that calls tinyMCE.init() is not called correctly. This commit ensures that tinyMCE.init() is called no matter what.
