### PR TITLE
BUG / Housekeeping of Widget code

### DIFF
--- a/code/widgets/ArchiveWidget.php
+++ b/code/widgets/ArchiveWidget.php
@@ -1,5 +1,7 @@
 <?php
+
 if(class_exists('Widget')) {
+	
 	/**
 	 * Shows a widget with viewing blog entries
 	 * by months or years.
@@ -7,27 +9,21 @@ if(class_exists('Widget')) {
 	 * @package blog
 	 */
 	class ArchiveWidget extends Widget {
-	private static $db = array(
+		
+		private static $db = array(
 			'DisplayMode' => 'Varchar'
 		);
 		
-	private static $has_one = array();
-		
-	private static $has_many = array();
-		
-	private static $many_many = array();
-		
-	private static $belongs_many_many = array();
-		
-	private static $defaults = array(
+		private static $defaults = array(
 			'DisplayMode' => 'month'
 		);
 		
-	private static $title = 'Browse by Date';
-
-	private static $cmsTitle = 'Blog Archive';
+		private static $title = 'Browse by Date';
 		
-	private static $description = 'Show a list of months or years in which there are blog posts, and provide links to them.';
+		private static $cmsTitle = 'Blog Archive';
+		
+		private static $description =
+			'Show a list of months or years in which there are blog posts, and provide links to them.';
 		
 		function getCMSFields() {
 			$fields = parent::getCMSFields(); 
@@ -61,20 +57,29 @@ if(class_exists('Widget')) {
 			$stage = Versioned::current_stage();
 			$suffix = (!$stage || $stage == 'Stage') ? "" : "_$stage";
 
-			$monthclause = method_exists(DB::getConn(), 'formattedDatetimeClause') ? DB::getConn()->formattedDatetimeClause('"Date"', '%m') : 'MONTH("Date")';
-			$yearclause  = method_exists(DB::getConn(), 'formattedDatetimeClause') ? DB::getConn()->formattedDatetimeClause('"Date"', '%Y') : 'YEAR("Date")';
+			if(method_exists(DB::getConn(), 'formattedDatetimeClause')) {
+				$monthclause = DB::getConn()->formattedDatetimeClause('"Date"', '%m');
+				$yearclause  = DB::getConn()->formattedDatetimeClause('"Date"', '%Y');
+			} else {
+				$monthclause = 'MONTH("Date")';
+				$yearclause  = 'YEAR("Date")';
+			}
 			
 			if($this->DisplayMode == 'month') {
 				$sqlResults = DB::query("
-					SELECT DISTINCT CAST($monthclause AS " . DB::getConn()->dbDataType('unsigned integer') . ") AS \"Month\", $yearclause AS \"Year\"
-					FROM \"SiteTree$suffix\" INNER JOIN \"BlogEntry$suffix\" ON \"SiteTree$suffix\".\"ID\" = \"BlogEntry$suffix\".\"ID\"
+					SELECT DISTINCT CAST($monthclause AS " . DB::getConn()->dbDataType('unsigned integer') . ")
+						AS \"Month\",
+						$yearclause AS \"Year\"
+					FROM \"SiteTree$suffix\" INNER JOIN \"BlogEntry$suffix\"
+						ON \"SiteTree$suffix\".\"ID\" = \"BlogEntry$suffix\".\"ID\"
 					WHERE \"ParentID\" IN (" . implode(', ', $ids) . ")
 					ORDER BY \"Year\" DESC, \"Month\" DESC;"
 				);
 			} else {
 				$sqlResults = DB::query("
 					SELECT DISTINCT $yearclause AS \"Year\" 
-					FROM \"SiteTree$suffix\" INNER JOIN \"BlogEntry$suffix\" ON \"SiteTree$suffix\".\"ID\" = \"BlogEntry$suffix\".\"ID\"
+					FROM \"SiteTree$suffix\" INNER JOIN \"BlogEntry$suffix\"
+						ON \"SiteTree$suffix\".\"ID\" = \"BlogEntry$suffix\".\"ID\"
 					WHERE \"ParentID\" IN (" . implode(', ', $ids) . ")
 					ORDER BY \"Year\" DESC"
 				);

--- a/code/widgets/BlogManagementWidget.php
+++ b/code/widgets/BlogManagementWidget.php
@@ -1,26 +1,20 @@
 <?php
+
 if(class_exists('Widget')) {
 
 	/**
 	 * Blog Management Widget
+	 * 
 	 * @package blog
 	 */
-class BlogManagementWidget extends Widget {
-	private static $db = array();
+	class BlogManagementWidget extends Widget {
 
-	private static $has_one = array();
-
-	private static $has_many = array();
-
-	private static $many_many = array();
-
-	private static $belongs_many_many = array();
-
-	private static $defaults = array();
-
-	private static $title = "Blog Management";
-	private static $cmsTitle = "Blog Management";
-	private static $description = "Provide a number of links useful for administering a blog. Only shown if the user is an admin.";
+		private static $title = "Blog Management";
+		
+		private static $cmsTitle = "Blog Management";
+		
+		private static $description =
+			"Provide a number of links useful for administering a blog. Only shown if the user is an admin.";
 
 		function CommentText() {
 

--- a/code/widgets/RSSWidget.php
+++ b/code/widgets/RSSWidget.php
@@ -1,27 +1,29 @@
 <?php
-if(class_exists('Widget')) {
+
+if (class_exists('Widget')) {
+	
+	/**
+	 * Presents a list of items from an RSS feed url
+	 * 
+	 * @package blog
+	 */
 	class RSSWidget extends Widget {
-	private static $db = array(
+
+		private static $db = array(
 			"RSSTitle" => "Text",
 			"RssUrl" => "Text",
 			"NumberToShow" => "Int"
 		);
-		
-	private static $has_one = array();
-		
-	private static $has_many = array();
-		
-	private static $many_many = array();
-		
-	private static $belongs_many_many = array();
-		
-	private static $defaults = array(
+
+		private static $defaults = array(
 			"NumberToShow" => 10,
 			"RSSTitle" => 'RSS Feed'
 		);
-	private static $cmsTitle = "RSS Feed";
-	private static $description = "Downloads another page's RSS feed and displays items in a list.";
-		
+
+		private static $cmsTitle = "RSS Feed";
+
+		private static $description = "Downloads another page's RSS feed and displays items in a list.";
+
 		/**
 		 * If the RssUrl is relative, convert it to absolute with the
 		 * current baseURL to avoid confusing simplepie.
@@ -45,7 +47,10 @@ if(class_exists('Widget')) {
 			$fields->merge(
 				new FieldList(
 					new TextField("RSSTitle", _t('RSSWidget.CT', "Custom title for the feed")),
-					new TextField("RssUrl", _t('RSSWidget.URL', "URL of the other page's RSS feed.  Please make sure this URL points to an RSS feed.")),
+					new TextField("RssUrl", _t(
+						'RSSWidget.URL',
+						"URL of the other page's RSS feed.  Please make sure this URL points to an RSS feed."
+					)),
 					new NumericField("NumberToShow", _t('RSSWidget.NTS', "Number of Items to show"))
 				)
 			);
@@ -54,8 +59,9 @@ if(class_exists('Widget')) {
 			
 			return $fields;
 		}
+		
 		function Title() {
-			return ($this->RSSTitle) ? $this->RSSTitle : 'RSS Feed';
+			return ($this->RSSTitle) ? $this->RSSTitle : _t('RSSWidget.DEFAULTTITLE', 'RSS Feed');
 		}
 		
 		function getFeedItems() {

--- a/code/widgets/SubscribeRSSWidget.php
+++ b/code/widgets/SubscribeRSSWidget.php
@@ -1,5 +1,7 @@
 <?php
+
 if(class_exists('Widget')) {
+	
 	/**
 	 * A simple widget that just shows a link
 	 * to this website's blog RSS, with an RSS
@@ -9,11 +11,11 @@ if(class_exists('Widget')) {
 	 */
 	class SubscribeRSSWidget extends Widget {
 		
-	private static $title = 'Subscribe via RSS';
-		
-	private static $cmsTitle = 'Subscribe via RSS widget';
-		
-	private static $description = 'Shows a link allowing a user to subscribe to this blog via RSS.';
+		private static $title = 'Subscribe via RSS';
+
+		private static $cmsTitle = 'Subscribe via RSS widget';
+
+		private static $description = 'Shows a link allowing a user to subscribe to this blog via RSS.';
 
 		/**
 		 * Return an absolute URL based on the BlogHolder

--- a/code/widgets/TagCloudWidget.php
+++ b/code/widgets/TagCloudWidget.php
@@ -1,150 +1,148 @@
 <?php
 
-class TagCloudWidget extends Widget {
-	private static $db = array(
-		"Title" => "Varchar",
-		"Limit" => "Int",
-		"Sortby" => "Varchar"
-	);
-	
-	private static $has_one = array();
-	
-	private static $has_many = array();
-	
-	private static $many_many = array();
-	
-	private static $belongs_many_many = array();
-	
-	private static $defaults = array(
-		"Title" => "Tag Cloud",
-		"Limit" => "0",
-		"Sortby" => "alphabet"
-	);
-	
-	private static $cmsTitle = "Tag Cloud";
-	private static $description = "Shows a tag cloud of tags on your blog.";
-
-	private static $popularities = array( 'not-popular', 'not-very-popular', 'somewhat-popular', 'popular', 'very-popular', 'ultra-popular' );
-	
-	function getCMSFields() {
-		$fields = parent::getCMSFields(); 
-		
-		$fields->merge(
-
-			new FieldList(
-				new TextField("Title", _t("TagCloudWidget.TILE", "Title")),
-				new TextField("Limit", _t("TagCloudWidget.LIMIT", "Limit number of tags")),
-				new OptionsetField("Sortby",_t("TagCloudWidget.SORTBY","Sort by"),array("alphabet"=>_t("TagCloudWidget.SBAL", "alphabet"),"frequency"=>_t("TagCloudWidget.SBFREQ", "frequency")))
-			)
-		);
-		
-		$this->extend('updateCMSFields', $fields);
-		
-		return $fields;
-	}
-	
-	function Title() {
-		return $this->Title ? $this->Title : 'Tag Cloud';
-	}
-	
-	function getTagsCollection() {
-		Requirements::themedCSS("tagcloud");
-		
-		$allTags = array();
-		$max = 0;
-		$container = BlogTree::current();
-		
-		$entries = $container->Entries();
-		
-		if($entries) {
-			foreach($entries as $entry) {
-				$theseTags = preg_split(" *, *", mb_strtolower(trim($entry->Tags)));
-				foreach($theseTags as $tag) {
-					if($tag != "") {
-						$allTags[$tag] = isset($allTags[$tag]) ? $allTags[$tag] + 1 : 1; //getting the count into key => value map
-						$max = ($allTags[$tag] > $max) ? $allTags[$tag] : $max;
-					}
-				}
-			}
-		
-			if($allTags) {		
-				//TODO: move some or all of the sorts to the database for more efficiency
-				if($this->Limit > 0) $allTags = array_slice($allTags, 0, $this->Limit, true);
-				
-				if($this->Sortby == "alphabet"){
-					$this->natksort($allTags);
-				} else{
-					uasort($allTags, array($this, "column_sort_by_popularity")); // sort by frequency
-				}
-				
-				$sizes = array();	
-				foreach ($allTags as $tag => $count) $sizes[$count] = true;
-				
-				$offset = 0; 
-				$numsizes = count($sizes)-1; //Work out the number of different sizes
-				$buckets = count(self::$popularities)-1;
-				
-				// If there are more frequencies than buckets, divide frequencies into buckets
-				if ($numsizes > $buckets) {
-					$numsizes = $buckets;
-				}
-				// Otherwise center use central buckets
-				else {
-					$offset   = round(($buckets-$numsizes)/2);
-				}
-				
-				foreach($allTags as $tag => $count) {
-					$popularity = round($count / $max * $numsizes) + $offset; $popularity=min($buckets,$popularity);
-					$class = self::$popularities[$popularity];
-					
-					$allTags[$tag] = array(
-						"Tag" => $tag,
-						"Count" => $count,
-						"Class" => $class,
-						"Link" => $container->Link('tag') . '/' . urlencode($tag)		
-					);
-				}
-			}
-			
-			$output = new ArrayList();
-			foreach($allTags as $tag => $fields) {
-				$output->push(new ArrayData($fields));
-			}
-			
-			return $output;	
-		}
-		
-		return;		
-	}
+if(class_exists('Widget')) {
 	
 	/**
-	 * Helper method to compare 2 Vars to work out the results.
-	 * @param mixed
-	 * @param mixed
-	 * @return int
+	 * A list of tags associated with blog posts
+	 * 
+	 * @package blog
 	 */
-	private function column_sort_by_popularity($a, $b){
-		if($a == $b) {
-			$result  = 0;
-		} 
-		else {
-			$result = $b - $a;
-		}
-		return $result;
-	}
+	class TagCloudWidget extends Widget {
+		
+		private static $db = array(
+			"Title" => "Varchar",
+			"Limit" => "Int",
+			"Sortby" => "Varchar"
+		);
 
-	private function natksort(&$aToBeSorted) {
-		$aResult = array();
-		$aKeys = array_keys($aToBeSorted);
-		natcasesort($aKeys);
-		foreach ($aKeys as $sKey) {
-		    $aResult[$sKey] = $aToBeSorted[$sKey];
-		}
-		$aToBeSorted = $aResult;
+		private static $defaults = array(
+			"Title" => "Tag Cloud",
+			"Limit" => "0",
+			"Sortby" => "alphabet"
+		);
 
-		return true;
+		private static $cmsTitle = "Tag Cloud";
+		private static $description = "Shows a tag cloud of tags on your blog.";
+
+		private static $popularities = array( 'not-popular', 'not-very-popular', 'somewhat-popular', 'popular', 'very-popular', 'ultra-popular' );
+
+		function getCMSFields() {
+			$fields = parent::getCMSFields(); 
+
+			$fields->merge(
+
+				new FieldList(
+					new TextField("Title", _t("TagCloudWidget.TILE", "Title")),
+					new TextField("Limit", _t("TagCloudWidget.LIMIT", "Limit number of tags")),
+					new OptionsetField("Sortby",_t("TagCloudWidget.SORTBY","Sort by"),array("alphabet"=>_t("TagCloudWidget.SBAL", "alphabet"),"frequency"=>_t("TagCloudWidget.SBFREQ", "frequency")))
+				)
+			);
+
+			$this->extend('updateCMSFields', $fields);
+
+			return $fields;
+		}
+
+		function Title() {
+			return $this->Title ? $this->Title : _t('TagCloudWidget.DEFAULTTITLE', 'Tag Cloud');
+		}
+
+		function getTagsCollection() {
+			Requirements::themedCSS("tagcloud");
+
+			$allTags = array();
+			$max = 0;
+			$container = BlogTree::current();
+
+			$entries = $container->Entries();
+
+			if($entries) {
+				foreach($entries as $entry) {
+					$theseTags = preg_split(" *, *", mb_strtolower(trim($entry->Tags)));
+					foreach($theseTags as $tag) {
+						if($tag != "") {
+							$allTags[$tag] = isset($allTags[$tag]) ? $allTags[$tag] + 1 : 1; //getting the count into key => value map
+							$max = ($allTags[$tag] > $max) ? $allTags[$tag] : $max;
+						}
+					}
+				}
+
+				if($allTags) {		
+					//TODO: move some or all of the sorts to the database for more efficiency
+					if($this->Limit > 0) $allTags = array_slice($allTags, 0, $this->Limit, true);
+
+					if($this->Sortby == "alphabet"){
+						$this->natksort($allTags);
+					} else{
+						uasort($allTags, array($this, "column_sort_by_popularity")); // sort by frequency
+					}
+
+					$sizes = array();	
+					foreach ($allTags as $tag => $count) $sizes[$count] = true;
+
+					$offset = 0; 
+					$numsizes = count($sizes)-1; //Work out the number of different sizes
+					$buckets = count(self::$popularities)-1;
+
+					// If there are more frequencies than buckets, divide frequencies into buckets
+					if ($numsizes > $buckets) {
+						$numsizes = $buckets;
+					}
+					// Otherwise center use central buckets
+					else {
+						$offset   = round(($buckets-$numsizes)/2);
+					}
+
+					foreach($allTags as $tag => $count) {
+						$popularity = round($count / $max * $numsizes) + $offset; $popularity=min($buckets,$popularity);
+						$class = self::$popularities[$popularity];
+
+						$allTags[$tag] = array(
+							"Tag" => $tag,
+							"Count" => $count,
+							"Class" => $class,
+							"Link" => $container->Link('tag') . '/' . urlencode($tag)		
+						);
+					}
+				}
+
+				$output = new ArrayList();
+				foreach($allTags as $tag => $fields) {
+					$output->push(new ArrayData($fields));
+				}
+
+				return $output;	
+			}
+
+			return;		
+		}
+
+		/**
+		 * Helper method to compare 2 Vars to work out the results.
+		 * @param mixed
+		 * @param mixed
+		 * @return int
+		 */
+		private function column_sort_by_popularity($a, $b){
+			if($a == $b) {
+				$result  = 0;
+			} 
+			else {
+				$result = $b - $a;
+			}
+			return $result;
+		}
+
+		private function natksort(&$aToBeSorted) {
+			$aResult = array();
+			$aKeys = array_keys($aToBeSorted);
+			natcasesort($aKeys);
+			foreach ($aKeys as $sKey) {
+				$aResult[$sKey] = $aToBeSorted[$sKey];
+			}
+			$aToBeSorted = $aResult;
+
+			return true;
+		}
 	}
 }
-
-
-?>


### PR DESCRIPTION
- TagCloudWidget not wrapped with `if(class_exists('Widget'))` check for dependency module
- Default titles for RSS Widget and TagCloudWidget not being translated. Added to en.yml (missing getlocalization for blog?)
- Fixed poor indentation, and excessive line length (scrutinizer errors)
- Removal of several blank `private static $relation = array()` that added no value
- Fix of many 'R S S' typos in lang. Should be 'RSS'
- Missing PHPDoc for widget classes
- Fixed missing EOL and removed closing ?> from php files for consistency

I noticed that http://www.getlocalization.com/silverstripe_blog/ doesn't have any actual strings loaded against it. Do I need to do some work here to populate getlocalization for the blog, or should I just leave it?
