### PR TITLE
BUG Fixed incorrect html encoding of SimplePie rss titles

### DIFF
--- a/code/widgets/RSSWidget.php
+++ b/code/widgets/RSSWidget.php
@@ -87,7 +87,7 @@ if(class_exists('Widget')) {
 
 					// Cast the Title
 					$title = new Text('Title');
-					$title->setValue($item->get_title());
+					$title->setValue(html_entity_decode($item->get_title()));
 
 					$output->push(new ArrayData(array(
 						'Title' => $title,


### PR DESCRIPTION
SimplePie values returned as titles will have HTML entities already encoded. E.g. `Saatchi &amp; Saatchi`. Since this value is rendered in the template via a `Text` field, it's necessary to convert these entities to their respective characters being passed in. This will fix issues with special characters being double escaped on the front end.

I would prefer this method to using a HTMLText field as it is more effective at preventing HTML injection attacks.
