### PR TITLE
BUG: Fixes #84 for tag 0.6.2 so blog can be loaded via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
 	"require":
 	{
 		"silverstripe/cms": "3.*",
-		"silverstripe/widgets": "dev-master"
+		"silverstripe/widgets": "*"
 	}
 }


### PR DESCRIPTION

I would like this pull request to be created as a new tag 0.6.3 this is to resolve the following issues

https://github.com/silverstripe/silverstripe-blog/issues/84

https://github.com/silverstripe/silverstripe-widgets/issues/49