### PR TITLE
Removed InheritSideBar db field, because it conflicts with the widget module

### DIFF
--- a/code/BlogTree.php
+++ b/code/BlogTree.php
@@ -24,13 +24,10 @@ class BlogTree extends Page {
 	
 	private static $db = array(
 		'Name' => 'Varchar(255)',
-		'InheritSideBar' => 'Boolean',
 		'LandingPageFreshness' => 'Varchar',
 	);
 	
-	private static $defaults = array(
-		'InheritSideBar' => True
-	);
+	private static $defaults = array();
 	
 	private static $has_one = array();
 


### PR DESCRIPTION
`InheritSideBar` is a field only applicable when using `Widgets`. It can be re-included as part of the widget module `WidgetPageExtension`
