### PR TITLE
Uncaught Exception: Object->__call(): the method 'data' does not exist on 'Security'

### DIFF
--- a/code/BlogTree.php
+++ b/code/BlogTree.php
@@ -50,21 +50,25 @@ class BlogTree extends Page {
 	 */
 	static function current($page = null) {
 		
-		if (!$page) {
+		if (!$page && Controller::has_curr()) {
 			$controller = Controller::curr();
-			if($controller) $page = $controller->data();
+			if ($controller->hasMethod('data')) {
+				$page = $controller->data();
+			}
 		}
 		
-		// If we _are_ a BlogTree, use us
-		if ($page instanceof BlogTree) return $page;
-		
-		// If page is a virtual page use that
-		if($page instanceof VirtualPage && $page->CopyContentFrom() instanceof BlogTree) return $page;
-		
-		// Or, if we a a BlogEntry underneath a BlogTree, use our parent
-		if($page->is_a("BlogEntry")) {
-			$parent = $page->getParent();
-			if($parent instanceof BlogTree) return $parent;
+		if ($page) {
+			// If we _are_ a BlogTree, use us
+			if ($page instanceof BlogTree) return $page;
+			
+			// If page is a virtual page use that
+			if($page instanceof VirtualPage && $page->CopyContentFrom() instanceof BlogTree) return $page;
+			
+			// Or, if we a a BlogEntry underneath a BlogTree, use our parent
+			if($page->is_a("BlogEntry")) {
+				$parent = $page->getParent();
+				if($parent instanceof BlogTree) return $parent;
+			}
 		}
 		
 		// Try to find a top-level BlogTree


### PR DESCRIPTION
I ran into the above error when I had the tagcloud widget included on a login page.  Looks like the security controller does not have a "data" method.  This pull request explicitly handles that situation in BlogTree::current().
