### PR TITLE
Feature/rss shortcode fix

### DIFF
--- a/code/BlogEntry.php
+++ b/code/BlogEntry.php
@@ -138,7 +138,7 @@ class BlogEntry extends Page {
 	 * To be used by RSSFeed. If RSSFeed uses Content field, it doesn't pull in correctly parsed content. 
 	 */ 
 	function RSSContent() {
-		return $this->Content();
+		return DBField::create_field('HTMLText', $this->Content());
 	}
 	
 	/**


### PR DESCRIPTION
The RSS feed of blog entries contain content that is not cast as HTMLText. This results in shortcodes not being converted correctly. 

This pull request cast Content to HTMLText when used by the RSSFeed.
