### PR TITLE
Add extension hooks to blog entry form

### DIFF
--- a/code/BlogEntry.php
+++ b/code/BlogEntry.php
@@ -44,19 +44,19 @@ class BlogEntry extends Page {
 	static $allow_wysiwyg_editing = true;
 	
 	/**
-	 * Overload so that the default date is today.
+	 * Overload so that the default date is today and the default author is the logged in Member.
 	 */
 	public function populateDefaults(){
 		parent::populateDefaults();
 		
 		$this->setField('Date', date('Y-m-d H:i:s', strtotime('now')));
+		$this->setField('Author', Member::currentUser() ? Member::currentUser()->getName() : '');
 	}
 	
 	function getCMSFields() {
 		Requirements::javascript('blog/javascript/bbcodehelp.js');
 		Requirements::themedCSS('bbcodehelp');
 		
-		$firstName = Member::currentUser() ? Member::currentUser()->FirstName : '';
 		$codeparser = new BBCodeParser();
 		
 		SiteTree::disableCMSFieldsExtensions();
@@ -71,7 +71,7 @@ class BlogEntry extends Page {
 		$fields->addFieldToTab("Root.Main", $dateField = new DatetimeField("Date", _t("BlogEntry.DT", "Date")),"Content");
 		$dateField->getDateField()->setConfig('showcalendar', true);
 		$dateField->getTimeField()->setConfig('timeformat', 'H:m:s');
-		$fields->addFieldToTab("Root.Main", new TextField("Author", _t("BlogEntry.AU", "Author"), $firstName),"Content");
+		$fields->addFieldToTab("Root.Main", new TextField("Author", _t("BlogEntry.AU", "Author")),"Content");
 		
 		if(!self::$allow_wysiwyg_editing) {
 			$fields->addFieldToTab("Root.Main", new LiteralField("BBCodeHelper", "<div id='BBCode' class='field'>" .

--- a/code/BlogHolder.php
+++ b/code/BlogHolder.php
@@ -283,6 +283,8 @@ class BlogHolder_Controller extends BlogTree_Controller {
 		} else {
 			$form->loadDataFrom(array("Author" => Cookie::get("BlogHolder_Name")));
 		}
+        
+        $this->extend("updateBlogEntryForm", $form);
 
 		return $form;
 	}
@@ -312,12 +314,16 @@ class BlogHolder_Controller extends BlogTree_Controller {
 		if(Object::has_extension($this->ClassName, 'Translatable')) {
 			$blogentry->Locale = $this->Locale; 
 		}
+        
+        $this->extend("onBeforePostBlog", $blogentry);
 
 		$oldMode = Versioned::get_reading_mode();
 		Versioned::reading_stage('Stage');
 		$blogentry->write();
 		$blogentry->publish("Stage", "Live");
 		Versioned::set_reading_mode($oldMode);
+        
+        $this->extend("onAfterPostBlog", $blogentry);
 
 		$this->redirect($this->Link());
 	}

--- a/code/BlogHolder.php
+++ b/code/BlogHolder.php
@@ -283,8 +283,8 @@ class BlogHolder_Controller extends BlogTree_Controller {
 		} else {
 			$form->loadDataFrom(array("Author" => Cookie::get("BlogHolder_Name")));
 		}
-        
-        $this->extend("updateBlogEntryForm", $form);
+
+		$this->extend("updateBlogEntryForm", $form);
 
 		return $form;
 	}
@@ -314,8 +314,8 @@ class BlogHolder_Controller extends BlogTree_Controller {
 		if(Object::has_extension($this->ClassName, 'Translatable')) {
 			$blogentry->Locale = $this->Locale; 
 		}
-        
-        $this->extend("onBeforePostBlog", $blogentry);
+
+		$this->extend("onBeforePostBlog", $blogentry);
 
 		$oldMode = Versioned::get_reading_mode();
 		Versioned::reading_stage('Stage');

--- a/tests/BlogEntryTest.php
+++ b/tests/BlogEntryTest.php
@@ -6,6 +6,29 @@
  */
 class BlogEntryTest extends SapphireTest {
 	static $fixture_file = 'blog/tests/BlogTest.yml';
+    
+	/**
+	* Tests that the blog entry populate defaults works
+	*/
+	public function testPopulateDefaults() {
+		$member = $this->objFromFixture("Member", "blogOwner1");
+		$member->logIn();
+
+		// Create manually, as from fixture seems to create entries
+		// multiple times
+		$entry = BlogEntry::create();
+		$entry->Title = "Test post";
+		$entry->URLSegment = "test-post";
+		$entry->Tags = "tag1,tag2";
+
+		// We cant test by the second, as that will most likely fail
+		$now = date('Y-m-d', strtotime('now'));
+
+		$this->assertContains($now, $entry->Date);
+		$this->assertEquals($member->getName(), $entry->Author);
+
+		$member->logOut();
+	}
 	
 	/**
 	 * Tests BBCode functionality


### PR DESCRIPTION
If we create more complex blog pages (with fields beyond the fields provided by this module) then we cannot edit this data using the "BlogEntryForm".

Adding extension hooks on both the BlogEntryForm and the postblog methods would allow developers to product more complex forms without having extend BlogHolder (and add additional, possibly unnecessary Model classes to the SiteTree).

Just a thought :-)

Mo