### PR TITLE
Break out templates and expand

### DIFF
--- a/code/model/Blog.php
+++ b/code/model/Blog.php
@@ -274,8 +274,12 @@ class Blog_Controller extends Page_Controller {
 		$posts = new PaginatedList($this->blogPosts);
 
 		// If pagination is set to '0' then no pagination will be shown.
-		if($this->PostsPerPage > 0) $posts->setPageLength($this->PostsPerPage);
-		else $posts->setPageLength($this->getBlogPosts()->count());
+		if($this->PostsPerPage > 0) {
+			$posts->setPageLength($this->PostsPerPage);
+		} else {
+			$pageSize = $this->getBlogPosts()->count() ?: 99999;
+			$posts->setPageLength($pageSize);
+		}
 
 		$start = $this->request->getVar($posts->getPaginationGetVar());
 		$posts->setPageStart($start);

--- a/code/model/BlogPost.php
+++ b/code/model/BlogPost.php
@@ -41,6 +41,10 @@ class BlogPost extends Page {
 		"Title",
 	);
 
+	private static $casting = array(
+		'Excerpt' => 'Text'
+	);
+
 	private static $allowed_children = array();
 
 	private static $default_sort = "PublishDate DESC";
@@ -75,7 +79,7 @@ class BlogPost extends Page {
 
 			// We're going to add the url segment to sidebar so we're making it a little lighter
 			$urlSegment = $fields->dataFieldByName('URLSegment');
-			$urlSegment->setURLPrefix('/' . Director::makeRelative($self->Parent()->Link()));
+			$urlSegment->setURLPrefix($self->Parent()->RelativeLink());
 
 			// Remove the MenuTitle and URLSegment from the main tab
 			$fields->removeFieldsFromTab('Root.Main', array(
@@ -117,7 +121,7 @@ class BlogPost extends Page {
 	/**
 	 * If no publish date is set, set the date to now.
 	**/
-	public function onBeforeWrite() {
+	protected function onBeforeWrite() {
 		parent::onBeforeWrite();
 		if(!$this->PublishDate) $this->setCastedField("PublishDate", time());
 	}

--- a/css/blog.css
+++ b/css/blog.css
@@ -1,0 +1,43 @@
+.no-sidebar .content-container.size3of4 {
+    width: 75%;
+}
+
+.blog-entry .post-image img {
+    width: 98.75%;
+}
+
+.blog-sidebar .WidgetHolder ul {
+    margin-left: 0;
+}
+    .blog-sidebar .WidgetHolder ul li {
+        list-style-type: none;
+    }
+
+#Form_CommentsForm + h4 {
+	clear: both;
+	padding-top: 35px;
+	display: block;
+}
+
+.typography ul.comments-list {
+	margin: 0;
+}
+
+.typography ul.comments-list > li {
+	list-style: none;
+	border-bottom: 1px solid #e5e5e5;
+	padding: 10px 0;
+}
+
+.typography ul.comments-list > li .action-links {
+	margin: 0;
+}
+
+.typography ul.comments-list > li .action-links li {
+	list-style: none;
+	margin-right: 10px;
+}
+
+.commenting-rss-feed {
+	clear: both;
+}

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -1,38 +1,62 @@
 en:
+  Blog:
+    Archive: Archive
+    Categories: Categories
+    Category: Category
+    Comments: Comments
+    DESCRIPTION: 'Adds a blog to your website.'
+    LumberjackTitle: 'Blog Posts'
+    NoPosts: 'There are no posts'
+    PLURALNAME: Blogs
+    Posted: Posted
+    PostedIn: 'Posted in'
+    PostsPerPage: 'Posts Per Page'
+    ReadMoreAbout: 'Read more about ''{title}''...'
+    SINGULARNAME: Blog
+    Tag: Tag
+    Tagged: Tagged
+    Tags: Tags
+  BlogArchiveWidget:
+    Blog: Blog
+    NumberToDisplay: 'No. to Display'
+    PLURALNAME: 'Blog Archive Widgets'
+    SINGULARNAME: 'Blog Archive Widget'
+    Type: Type
+  BlogCategoriesWidget:
+    Blog: Blog
+    PLURALNAME: 'Blog Categories Widgets'
+    SINGULARNAME: 'Blog Categories Widget'
+  BlogCategory:
+    PLURALNAME: 'Blog Categories'
+    SINGULARNAME: 'Blog Category'
+    Title: Title
+  BlogPost:
+    Categories: Categories
+    DESCRIPTION: 'Generic content page'
+    FeaturedImage: 'Featured Image'
+    PLURALNAME: 'Blog Posts'
+    PageTitleLabel: 'Post Title'
+    PublishDate: 'Publish Date'
+    SINGULARNAME: 'Blog Post'
+    Tags: Tags
+  BlogRecentPostsWidget:
+    Blog: Blog
+    NumberOfPosts: 'Number of Posts'
+    PLURALNAME: 'Blog Recent Posts Widgets'
+    SINGULARNAME: 'Blog Recent Posts Widget'
+  BlogTag:
+    PLURALNAME: 'Blog Tags'
+    SINGULARNAME: 'Blog Tag'
+    Title: Title
+  BlogTagsWidget:
+    Blog: Blog
+    PLURALNAME: 'Blog Tags Widgets'
+    SINGULARNAME: 'Blog Tags Widget'
   GridFieldAddByDBField:
+    Add: 'Add {name}'
     AddFail: 'Unable to save {class} to the database.'
     PermissionFail: 'You don''t have permission to create a {class}.'
-    Add: 'Add {name}'
   GridFieldBlogPostState:
-    StateTitle: 'State'
-    Draft: '<i class="btn-icon blog-icon btn-icon-pencil"></i> Saved as Draft on {date}'
-    Published: '<i class="btn-icon blog-icon btn-icon-accept"></i> Published on {date}'
-    Timer: '<i class="blog-icon blog-icon-timer"></i> Publish at {date}'
-    Modified: 'Modified'
-  BlogPost:
-    PublishDate: 'Publish Date'
-    Categories: 'Categories'
-    Tags: 'Tags'
-    FeaturedImage: 'Featured Image'
-    PageTitleLabel: 'Post Title'
-  Blog:
-    BlogPosts: 'Blog Posts'
-    Categories: 'Categories'
-    Tags: 'Tags'
-    PostsPerPage: 'Posts Per Page'
-  BlogTag:
-    Title: 'Title'
-  BlogCategory:
-    Title: 'Title'
-  BlogRecentPostsWidget:
-    Blog: 'Blog'
-    NumberOfPosts: 'Number of Posts'
-  BlogCategoriesWidget:
-    Blog: 'Blog'
-  BlogArchiveWidget:
-    Blog: 'Blog'
-    Monthly: 'Monthly'
-    Yearly: 'Yearly'
-    NumberToDisplay: 'Number to Display'
-  BlogTagsWidget:
-    Blog: 'Blog'
+    Draft: '<i class="btn-icon gridfield-icon btn-icon-pencil"></i> Saved as Draft on {date}'
+    Published: '<i class="btn-icon gridfield-icon btn-icon-accept"></i> Published on {date}'
+    Timer: '<i class="gridfield-icon blog-icon-timer"></i> Publish at {date}'

--- a/templates/Includes/BlogSideBar.ss
+++ b/templates/Includes/BlogSideBar.ss
@@ -1,0 +1,5 @@
+<% if $SideBarView %>
+    <div class="blog-sidebar typography unit size1of4 lastUnit">
+        $SideBarView
+    </div>
+<% end_if %>

--- a/templates/Includes/EntryMeta.ss
+++ b/templates/Includes/EntryMeta.ss
@@ -1,0 +1,25 @@
+<p class="blog-post-meta">
+    <% if $Categories.exists %>
+        <%t Blog.PostedIn "Posted in" %>
+		<% loop $Categories %>
+			<a href="$Link" title="$Title">$Title</a><% if not Last %>, <% else %>;<% end_if %>
+		<% end_loop %>
+	<% end_if %>
+	
+    <% if $Tags.exists %>
+        <%t Blog.Tagged "Tagged" %>
+		<% loop $Tags %>
+			<a href="$Link" title="$Title">$Title</a><% if not Last %>, <% else %>;<% end_if %>
+		<% end_loop %>
+	<% end_if %>
+    
+    <% if $Comments.exists %>
+        <a href="{$Link}#comments-holder">
+            <%t Blog.Comments "Comments" %>
+            $Comments.count
+        </a>;
+	<% end_if %>
+    
+	<%t Blog.Posted "Posted" %>
+    <a href="$MonthlyArchiveLink">$PublishDate.ago</a>
+</p>

--- a/templates/Includes/Pagination.ss
+++ b/templates/Includes/Pagination.ss
@@ -1,0 +1,25 @@
+<%-- NOTE: Before including this, you will need to wrap the include in a with block  --%>
+
+<% if $MoreThanOnePage %>
+    <p class="pagination">
+        <% if $NotFirstPage %>
+            <a class="prev" href="{$PrevLink}">&larr;</a>
+        <% end_if %>
+    
+        <% loop $Pages %>
+            <% if $CurrentBool %>
+                <span>$PageNum</span>
+            <% else %>
+                <% if $Link %>
+                    <a href="$Link">$PageNum</a>
+                <% else %>
+                    <span>...</span>
+                <% end_if %>
+            <% end_if %>
+        <% end_loop %>
+            
+        <% if $NotLastPage %>
+            <a class="next" href="{$NextLink}">&rarr;</a>
+        <% end_if %>
+    </p>
+<% end_if %>

--- a/templates/Layout/Blog.ss
+++ b/templates/Layout/Blog.ss
@@ -1,0 +1,72 @@
+<% require themedCSS('blog', 'blog') %>
+
+<div class="blog-entry content-container <% if $SideBarView %>unit size3of4<% end_if %>">
+
+    <article>
+        <h1>
+            <% if $ArchiveYear %>
+                <%t Blog.Archive "Archive" %>:
+                <% if $ArchiveDay %>
+                    $ArchiveDate.Nice
+                <% else_if $ArchiveMonth %>
+                    $ArchiveDate.format("F, Y")
+                <% else %>
+                    $ArchiveDate.format("Y")
+                <% end_if %>
+            <% else_if $CurrentTag %>
+                <%t Blog.Tag "Tag" %>: $CurrentTag.Title
+            <% else_if $CurrentCategory %>
+                <%t Blog.Category "Category" %>: $CurrentCategory.Title
+            <% else %>
+                $Title
+            <% end_if %>
+        </h1>
+        
+        <div class="content">$Content</div>
+        
+        <% if $PaginatedList.Exists %>
+            <% loop $PaginatedList %>
+                <div class="post-summary">
+                    <h2>
+                        <a href="$Link" title="<%t Blog.ReadMoreAbout "Read more about '{title}'..." title=$Title %>">
+                            <% if $MenuTitle %>$MenuTitle
+                            <% else %>$Title<% end_if %>
+                        </a>
+                    </h2>
+                    
+                    <p class="post-image">
+                        <a href="$Link" <%t Blog.ReadMoreAbout "Read more about '{title}'..." title=$Title %>>
+                            $FeaturedImage.setWidth(795)
+                        </a>
+                    </p>
+                    
+                    <% if $Excerpt %>
+                        <p>
+                            $Excerpt
+                            <a href="$Link">
+                                <%t Blog.ReadMoreAbout "Read more about '{title}'..." title=$Title %>
+                            </a>
+                        </p>
+                    <% else %>
+                        <p><a href="$Link">
+                            <%t Blog.ReadMoreAbout "Read more about '{title}'..." title=$Title %>
+                        </a></p>
+                    <% end_if %>
+                    
+                    <% include EntryMeta %>
+                </div>
+            <% end_loop %>
+        <% else %>
+            <p><%t Blog.NoPosts "There are no posts" %></p>
+        <% end_if %>
+    </article>
+    
+    $Form
+    $PageComments
+        
+    <% with $PaginatedList %>
+		<% include Pagination %>
+	<% end_with %>
+</div>
+
+<% include BlogSideBar %>

--- a/templates/Layout/BlogPost.ss
+++ b/templates/Layout/BlogPost.ss
@@ -1,0 +1,20 @@
+<% require themedCSS('blog', 'blog') %>
+
+<div class="blog-entry content-container <% if $SideBarView %>unit size3of4<% end_if %>">
+	<article>
+		<h1>$Title</h1>
+        
+        <% if $FeaturedImage %>
+			<p class="post-image">$FeaturedImage.setWidth(795)</p>
+		<% end_if %>
+        
+		<div class="content">$Content</div>
+
+		<% include EntryMeta %>
+	</article>
+    
+    $Form
+	$PageComments
+</div>
+
+<% include BlogSideBar %>

--- a/templates/WidgetHolder.ss
+++ b/templates/WidgetHolder.ss
@@ -1,0 +1,4 @@
+<nav class="secondary">
+	<h3>$Title</h3>
+	$Content
+</nav>

--- a/templates/widgets/BlogArchiveWidget.ss
+++ b/templates/widgets/BlogArchiveWidget.ss
@@ -1,7 +1,12 @@
-<% if Archive %>
+<% if $Archive %>
 	<ul>
-		<% loop Archive %>
-			<li><a href="$Link" title="$Title">$Title</a></li>
+		<% loop $Archive %>
+			<li>
+				<a href="$Link" title="$Title">
+					<span class="arrow">&rarr;</span>
+					<span class="text">$Title</span>
+				</a>
+			</li>
 		<% end_loop %>
 	</ul>
 <% end_if %>

--- a/templates/widgets/BlogCategoriesWidget.ss
+++ b/templates/widgets/BlogCategoriesWidget.ss
@@ -1,7 +1,12 @@
-<% if Categories %>
+<% if $Categories %>
 	<ul>
-		<% loop Categories %>
-			<li><a href="$Link" title="$Title">$Title</a></li>
+		<% loop $Categories %>
+			<li>
+				<a href="$Link" title="$Title">
+					<span class="arrow">&rarr;</span>
+					<span class="text">$Title</span>
+				</a>
+			</li>
 		<% end_loop %>
 	</ul>
 <% end_if %>

--- a/templates/widgets/BlogRecentPostsWidget.ss
+++ b/templates/widgets/BlogRecentPostsWidget.ss
@@ -1,7 +1,12 @@
-<% if Posts %>
+<% if $Posts %>
 	<ul>
-		<% loop Posts %>
-			<li><a href="$Link" title="$Title">$Title</a></li>
+		<% loop $Posts %>
+			<li>
+				<a href="$Link" title="$Title">
+					<span class="arrow">&rarr;</span>
+					<span class="text">$Title</span>
+				</a>
+			</li>
 		<% end_loop %>
 	</ul>
 <% end_if %>

--- a/templates/widgets/BlogTagsWidget.ss
+++ b/templates/widgets/BlogTagsWidget.ss
@@ -1,7 +1,12 @@
-<% if Tags %>
+<% if $Tags %>
 	<ul>
-		<% loop Tags %>
-			<li><a href="$Link" title="$Title">$Title</a></li>
+		<% loop $Tags %>
+			<li>
+				<a href="$Link" title="$Title">
+					<span class="arrow">&rarr;</span>
+					<span class="text">$Title</span>
+				</a>
+			</li>
 		<% end_loop %>
 	</ul>
 <% end_if %>


### PR DESCRIPTION
I've reviewed and squashed https://github.com/silverstripe/silverstripe-blog/pull/146, and added a few fixes based on @micmania1's feedback on https://github.com/silverstripe/silverstripe-blog/pull/144

- PaginatedList still uses PaginatedList class to keep API consistent
- All templates from @Makreig have been more or less unchanged, with only fixes made to the template syntax (missing $, "", etc).
- Use themedCSS for blog css file (to allow extension by user code / themes)
- Add XML default encoding to $Excerpt (xss vulnerability)