### PR TITLE
Fixed blogentry migration

### DIFF
--- a/code/compat/pages/BlogEntry.php
+++ b/code/compat/pages/BlogEntry.php
@@ -52,6 +52,9 @@ class BlogEntry extends BlogPost implements MigratableObject {
 		if($this->ClassName === 'BlogEntry') {
 			$this->ClassName = 'BlogPost';
 			$this->write();
+			if($this->isPublished()){
+				$this->doPublish();
+			}
 		}
 	}
 

--- a/code/compat/tasks/BlogMigrationTask.php
+++ b/code/compat/tasks/BlogMigrationTask.php
@@ -24,6 +24,8 @@ class BlogMigrationTask extends MigrationTask {
 	}
 
 	public function up() {
+		SS_ClassLoader::instance()->getManifest()->regenerate(false);
+
 		$classes = ClassInfo::implementorsOf('MigratableObject');
 		$this->message('Migrating legacy blog records');
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "silverstripe/blog",
+    "name": "heffaklump90/blog",
     "description": "A fresh take on blogging in Silverstripe set out to tackle the issue of a cluttered Site Tree.",
     "keywords": ["silverstripe", "blog", "news"],
     "type": "silverstripe-module",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "heffaklump90/blog",
+    "name": "silverstripe/blog",
     "description": "A fresh take on blogging in Silverstripe set out to tackle the issue of a cluttered Site Tree.",
     "keywords": ["silverstripe", "blog", "news"],
     "type": "silverstripe-module",


### PR DESCRIPTION
Forced a regeneration of class manifest. The call to BlogEntry::get() returned an empty set without it
Also added an explicit publish of the already published blog entries, otherwise I had to go through and publish them all again.