### PR TITLE
Make BlogPost::isAuthor public

### DIFF
--- a/code/model/BlogPost.php
+++ b/code/model/BlogPost.php
@@ -72,7 +72,7 @@ class BlogPost extends Page {
 	 * @param Member $member
 	 * @return boolean
 	 */
-	protected function isAuthor($member) {
+	public function isAuthor($member) {
 		if(!$member || !$member->exists()) return false;
 
 		$list = $this->Authors();


### PR DESCRIPTION
You can't use isAuthor in extensions because it's currently protected.