### PR TITLE
API Add role-helpers for templates

### DIFF
--- a/code/model/Blog.php
+++ b/code/model/Blog.php
@@ -155,6 +155,25 @@ class Blog extends Page implements PermissionProvider {
 	}
 
 	/**
+	 * Determine the role of the given member
+	 * Call be called via template to determine the current user
+	 *
+	 * E.g. `Hello $RoleOf($CurrentMember.ID)`
+	 *
+	 * @param Member|integer $member
+	 * @return string|null Author, Editor, Writer, Contributor, or null if no role
+	 */
+	public function RoleOf($member) {
+		if(is_numeric($member)) $member = DataObject::get_by_id('Member', $member);
+		if(!$member) return null;
+
+		// Check each role
+		if($this->isEditor($member)) return _t('Blog.EDITOR', 'Editor');
+		if($this->isWriter($member)) return _t('Blog.WRITER', 'Writer');
+		if($this->isContributor($member)) return _t('Blog.CONTRIBUTOR', 'Contributor');
+	}
+
+	/**
 	 * Determine if the given member belongs to the given subrelation
 	 *
 	 * @param Member $member

--- a/code/model/BlogPost.php
+++ b/code/model/BlogPost.php
@@ -83,6 +83,27 @@ class BlogPost extends Page {
 		return $list->byID($member->ID) !== null;
 	}
 
+	/**
+	 * Determine the role of the given member
+	 * Call be called via template to determine the current user
+	 *
+	 * E.g. `Hello $RoleOf($CurrentMember.ID)`
+	 *
+	 * @param Member|integer $member
+	 * @return string|null Author, Editor, Writer, Contributor, or null if no role
+	 */
+	public function RoleOf($member) {
+		if(is_numeric($member)) $member = DataObject::get_by_id('Member', $member);
+		if(!$member) return null;
+
+		// Check if this member is an author
+		if($this->isAuthor($member)) return _t("BlogPost.AUTHOR", "Author");
+
+		// Check parent role
+		$parent = $this->Parent();
+		if($parent instanceof Blog) return $parent->RoleOf($member);
+	}
+
 
 	public function getCMSFields() {
 		Requirements::css(BLOGGER_DIR . '/css/cms.css');

--- a/tests/BlogTest.php
+++ b/tests/BlogTest.php
@@ -109,6 +109,16 @@ class BlogTest extends SapphireTest {
 		$contributor = $this->objFromFixture('Member', 'contributor');
 		$visitor = $this->objFromFixture('Member', 'visitor');
 
+		// Check roleof
+		$this->assertEquals('Editor', $blog->RoleOf($editor));
+		$this->assertEquals('Contributor', $blog->RoleOf($contributor));
+		$this->assertEquals('Writer', $blog->RoleOf($writer));
+		$this->assertEmpty($blog->RoleOf($visitor));
+		$this->assertEquals('Author', $postA->RoleOf($writer));
+		$this->assertEquals('Author', $postA->RoleOf($contributor));
+		$this->assertEquals('Editor', $postA->RoleOf($editor));
+		$this->assertEmpty($postA->RoleOf($visitor));
+
 		// Check that editors have all permissions on their own blog
 		$this->assertTrue($blog->canEdit($editor));
 		$this->assertFalse($blog2->canEdit($editor));


### PR DESCRIPTION
This can also be used by other parts of the code, e.g. email notifications, to customise elements for individuals.