### PR TITLE
Adjusted minimum stability flag to reflect dev-develop usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,7 @@
 	},
 	"replace": {
 		"micmania1/silverstripe-blog": "*"
-	}
+	},
+	"minimum-stability": "dev",
+	"prefer-stable": true
 }


### PR DESCRIPTION
Scrutinizer is having trouble, and I think this might help it along.