### PR TITLE
BUG Fix blogtree with non-blogpost children breaking on migration

### DIFF
--- a/code/compat/pages/BlogTree.php
+++ b/code/compat/pages/BlogTree.php
@@ -3,7 +3,7 @@
 /**
  * @deprecated since version 2.0
  */
-class BlogTree extends Blog implements MigratableObject {
+class BlogTree extends Page implements MigratableObject {
 
 	private static $hide_ancestor = 'BlogTree';
 
@@ -19,7 +19,7 @@ class BlogTree extends Blog implements MigratableObject {
 
 	public function up() {
 		if($this->ClassName === 'BlogTree') {
-			$this->ClassName = 'Blog';
+			$this->ClassName = 'Page';
 			$this->write();
 		}
 	}
@@ -28,5 +28,5 @@ class BlogTree extends Blog implements MigratableObject {
 /**
  * @deprecated since version 2.0
  */
-class BlogTree_Controller extends Blog_Controller {
+class BlogTree_Controller extends Page_Controller {
 }


### PR DESCRIPTION
Since Blog has `allowed_children = array('BlogPost')`, attempting to migrate a BlogTree with other child types (such as BlogHolder) will cause an error. It's safer to turn these into basic Pages instead.