### PR TITLE
FIX: Fix to allow use of foreign text as tags and categories.  Fixes …

### DIFF
--- a/code/model/Blog.php
+++ b/code/model/Blog.php
@@ -803,9 +803,14 @@ class Blog_Controller extends Page_Controller {
 		 */
 		$dataRecord = $this->dataRecord;
 
-		$tag = $this->request->param('Tag');
+		// get the tag value and generate a URL Segment for it
+		// use the URL segment for searching
+		$tagvalue = $this->request->param('Tag');
+		if($tagvalue) {
+			$tempTag = new BlogTag();
+	                $tempTag->Title = $tagvalue;
+	                $tag = $tempTag->generateURLSegment();
 
-		if($tag) {
 			return $dataRecord->Tags()
 				->filter('URLSegment', $tag)
 				->first();
@@ -844,9 +849,12 @@ class Blog_Controller extends Page_Controller {
 		 */
 		$dataRecord = $this->dataRecord;
 
-		$category = $this->request->param('Category');
+		$categoryValue = $this->request->param('Category');
 
-		if($category) {
+		if($categoryValue) {
+			$tempCategory = new BlogCategory();
+			$tempCategory->Title = $categoryValue;
+			$category = $tempCategory->generateURLSegment();
 			return $dataRecord->Categories()
 				->filter('URLSegment', $category)
 				->first();


### PR DESCRIPTION
Instead of using the URL parameter directly for a tag or category value, generate a URL segment initially and search using that.  This fixes the issue of likes of Thai text not being found.