### PR TITLE
Updated Tag Field version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	"require": {
 		"silverstripe/cms": ">=3.1.0",
 		"silverstripe/lumberjack": "~1.1",
-		"silverstripe/tagfield": "2.0.x-dev"
+		"silverstripe/tagfield": "~1.0.0"
 	},
 	"require-dev": {
 		"phpunit/PHPUnit": "~3.7@stable"


### PR DESCRIPTION
Version change looks strange, but it's because `2.0.x-dev` was a major version off. Only `0.x` releases existed, previously. Just tagged `1.0.0`.