### PR TITLE
Escape $stage

### DIFF
--- a/code/extensions/BlogFilter.php
+++ b/code/extensions/BlogFilter.php
@@ -23,6 +23,7 @@ class BlogFilter extends Lumberjack {
 				$stage = '_' . $stage;
 			}
 
+			$stage = Convert::raw2sql($stage);
 			$dataQuery = $staged->dataQuery()
 				->innerJoin('BlogPost', sprintf('"BlogPost%s"."ID" = "SiteTree%s"."ID"', $stage, $stage))
 				->where(sprintf('"PublishDate" < \'%s\'', Convert::raw2sql(SS_Datetime::now())));


### PR DESCRIPTION
Although I don't *think* this is vulnerable, the $stage variable ultimately comes from a $_GET parameter so should be escaped. Without this the security remains weak and could cause issues if the Versioned code is changed.