### PR TITLE
FIX Ensures old blog 1.0 style author names are migrated into 2.0 AuthorNames

### DIFF
--- a/code/compat/pages/BlogEntry.php
+++ b/code/compat/pages/BlogEntry.php
@@ -49,6 +49,7 @@ class BlogEntry extends BlogPost implements MigratableObject {
 		}
 
 		$this->PublishDate = $this->Date;
+		$this->AuthorNames = $this->Author;
 
 		// If a user has subclassed BlogEntry, it should not be turned into a BlogPost.
 		if($this->ClassName === 'BlogEntry') {


### PR DESCRIPTION
Found that old 1.0 blog author names were not being migrated over to the new 2.0 AuthorNames (noted that there is now also a relationship between Member and BlogPost). The old 1.0 did not have this relationship so when migrating no authors are brought across from BlogEntry into BlogPost during the MigrationTask.