### PR TITLE
FIX Migration of blog 1.0 to 2.0 was broken

### DIFF
--- a/code/compat/pages/BlogHolder.php
+++ b/code/compat/pages/BlogHolder.php
@@ -31,14 +31,36 @@ class BlogHolder extends BlogTree implements MigratableObject {
 		return false;
 	}
 
+
+	//Overload these to stop the Uncaught Exception: Object->__call(): the method 'parent' does not exist on 'BlogHolder' error.
+	public function validURLSegment() {
+		return true;
+	}
+	public function syncLinkTracking() {
+		return null;
+	}
+
 	/**
 	 * {@inheritdoc}
 	 */
 	public function up() {
+
+		$published = $this->IsPublished();
+
 		if($this->ClassName === 'BlogHolder') {
 			$this->ClassName = 'Blog';
+			$this->RecordClassName = 'Blog';
 			$this->write();
 		}
+
+		if($published){
+			$this->publish('Stage','Live');
+			$message = "PUBLISHED: ";
+		} else {
+			$message = "DRAFT: ";
+		}
+		
+		return $message . $this->Title;
 	}
 }
 

--- a/code/compat/pages/BlogTree.php
+++ b/code/compat/pages/BlogTree.php
@@ -28,10 +28,20 @@ class BlogTree extends Page implements MigratableObject {
 	 * {@inheritdoc}
 	 */
 	public function up() {
+		$published = $this->IsPublished();
 		if($this->ClassName === 'BlogTree') {
 			$this->ClassName = 'Page';
+			$this->RecordClassName = 'Page';
 			$this->write();
 		}
+		if($published){
+			$this->publish('Stage','Live');
+			$message = "PUBLISHED: ";
+		} else {
+			$message = "DRAFT: ";
+		}
+		
+		return $message . $this->Title;
 	}
 }
 

--- a/code/compat/widgets/ArchiveWidget.php
+++ b/code/compat/widgets/ArchiveWidget.php
@@ -46,5 +46,7 @@ class ArchiveWidget extends BlogArchiveWidget implements MigratableObject {
 
 		$this->ClassName = 'BlogArchiveWidget';
 		$this->write();
+		return "Migrated " . $this->ArchiveType . " archive widget";
+
 	}
 }

--- a/code/compat/widgets/TagCloudWidget.php
+++ b/code/compat/widgets/TagCloudWidget.php
@@ -39,5 +39,6 @@ class TagCloudWidget extends BlogTagsWidget implements MigratableObject {
 	public function up() {
 		$this->ClassName = 'BlogTagsWidget';
 		$this->write();
+		return "Migrated " . $this->Title . " widget";
 	}
 }


### PR DESCRIPTION
@assertchris @tractorcow I found the existing blog migration task actually broken my blog site when run (only local of course :D).

I have reworked it a little to ensure that those posts that were published or draft remain so in the new 2.0 version of blog.

Fixed the issue of tags being repeatedly migrated for each BlogEntry which caused lots of duplicate tags.

A few other minor hacks and improvements. It's not the prettiest but it works. Not I have removed the migration task from running in the build task. I figure it is something that should be consciously run by the migrator rather than slipping it in during a build task. This is of course up for debate however this is at least a step forward for blog 1.0 -> 2.0 migration.