### PR TITLE
DOCS Updating information about BlogMigrationTask

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ silverstripe/comments: *
 composer require silverstripe/blog 2.0.x-dev
 ```
 
-## Upgrading
+## Upgrading legacy blog to 2.0
 
-If you're upgrading from an earlier version to 2.0, running a `dev/build` will migrate your legacy blog to the new version.
+If you're upgrading from blog version 1.0 to 2.0 you will need to run the `BlogMigrationTask`. Run the task using `dev/tasks/BlogMigrationTask` either via the browser or sake CLI to migrate your legacy blog to the new version data structure.
 
 ## Usage
 


### PR DESCRIPTION
This no longer automatically runs during dev/build. Migration should be conscious decision to run when a developer decides to update and avoids the risk of accidentally migrating on a live site when perhaps this was not the intention. I mention the move from 1.0 to 2.0 as this is a safe migration that some version old versions. Likely the upgrade path would be best if (1) Upgrade you really old blog up to 1.0 (2) Update your codebase to 2.0 code (3) Run the migration task.