### PR TITLE
Extended tags and categories widgets

### DIFF
--- a/code/widgets/BlogCategoriesWidget.php
+++ b/code/widgets/BlogCategoriesWidget.php
@@ -26,7 +26,11 @@ class BlogCategoriesWidget extends Widget {
 	/**
 	 * @var array
 	 */
-	private static $db = array();
+	private static $db = array(
+		'Limit' => 'Int',
+		'Order' => 'Varchar',
+		'Direction' => 'Varchar',
+	);
 
 	/**
 	 * @var array
@@ -39,27 +43,52 @@ class BlogCategoriesWidget extends Widget {
 	 * {@inheritdoc}
 	 */
 	public function getCMSFields() {
-		$this->beforeUpdateCMSFields(function ($fields) {
-			/**
-			 * @var FieldList $fields
-			 */
-			$fields->push(
-				DropdownField::create('BlogID', _t('BlogCategoriesWidget.Blog', 'Blog'), Blog::get()->map())
+		$this->beforeUpdateCMSFields(function (FieldList $fields) {
+			$fields[] = DropdownField::create(
+				'BlogID', _t('BlogCategoriesWidget.Blog', 'Blog'), Blog::get()->map()
 			);
+
+			$fields[] = NumericField::create(
+				'Limit', _t('BlogCategoriesWidget.Limit.Label', 'Limit'), 0
+			)
+				->setDescription(_t('BlogCategoriesWidget.Limit.Description', 'Limit the number of categories shown by this widget (set to 0 to show all categories).'))
+				->setMaxLength(3);
+
+			$fields[] = DropdownField::create(
+				'Order', _t('BlogCategoriesWidget.Sort.Label', 'Sort'), array('Title' => 'Title', 'Created' => 'Created', 'LastUpdated' => 'Updated')
+			)
+				->setDescription(_t('BlogCategoriesWidget.Sort.Description', 'Change the order of categories shown by this widget.'));
+
+			$fields[] = DropdownField::create(
+				'Direction', _t('BlogCategoriesWidget.Direction.Label', 'Direction'), array('ASC' => 'Ascending', 'DESC' => 'Descending')
+			)
+				->setDescription(_t('BlogCategoriesWidget.Direction.Description', 'Change the direction of ordering of categories shown by this widget.'));
 		});
 
 		return parent::getCMSFields();
 	}
 
 	/**
-	 * @return array
+	 * @return DataList
 	 */
 	public function getCategories() {
-		if($blog = $this->Blog()) {
-			return $blog->Categories();
+		$blog = $this->Blog();
+
+		if (!$blog) {
+			return array();
 		}
 
-		return array();
+		$query = $blog->Categories();
+
+		if ($this->Limit) {
+			$query = $query->limit(Convert::raw2sql($this->Limit));
+		}
+
+		if ($this->Order && $this->Direction) {
+			$query = $query->sort(Convert::raw2sql($this->Order), Convert::raw2sql($this->Direction));
+		}
+
+		return $query;
 	}
 }
 

--- a/code/widgets/BlogTagsWidget.php
+++ b/code/widgets/BlogTagsWidget.php
@@ -26,7 +26,11 @@ class BlogTagsWidget extends Widget {
 	/**
 	 * @var array
 	 */
-	private static $db = array();
+	private static $db = array(
+		'Limit' => 'Int',
+		'Order' => 'Varchar',
+		'Direction' => 'Varchar',
+	);
 
 	/**
 	 * @var array
@@ -39,27 +43,52 @@ class BlogTagsWidget extends Widget {
 	 * {@inheritdoc}
 	 */
 	public function getCMSFields() {
-		$this->beforeUpdateCMSFields(function ($fields) {
-			/**
-			 * @var FieldList $fields
-			 */
-			$fields->push(
-				DropdownField::create('BlogID', _t('BlogTagsWidget.Blog', 'Blog'), Blog::get()->map())
+		$this->beforeUpdateCMSFields(function (Fieldlist $fields) {
+			$fields[] = DropdownField::create(
+				'BlogID', _t('BlogTagsWidget.Blog', 'Blog'), Blog::get()->map()
 			);
+
+			$fields[] = NumericField::create(
+				'Limit', _t('BlogTagsWidget.Limit.Label', 'Limit'), 0
+			)
+				->setDescription(_t('BlogTagsWidget.Limit.Description', 'Limit the number of tags shown by this widget (set to 0 to show all tags).'))
+				->setMaxLength(3);
+
+			$fields[] = DropdownField::create(
+				'Order', _t('BlogTagsWidget.Sort.Label', 'Sort'), array('Title' => 'Title', 'Created' => 'Created', 'LastUpdated' => 'Updated')
+			)
+				->setDescription(_t('BlogTagsWidget.Sort.Description', 'Change the order of tags shown by this widget.'));
+
+			$fields[] = DropdownField::create(
+				'Direction', _t('BlogTagsWidget.Direction.Label', 'Direction'), array('ASC' => 'Ascending', 'DESC' => 'Descending')
+			)
+				->setDescription(_t('BlogTagsWidget.Direction.Description', 'Change the direction of ordering of tags shown by this widget.'));
 		});
 
 		return parent::getCMSFields();
 	}
 
 	/**
-	 * @return array
+	 * @return DataList
 	 */
 	public function getTags() {
-		if($blog = $this->Blog()) {
-			return $blog->Tags();
+		$blog = $this->Blog();
+
+		if (!$blog) {
+			return array();
 		}
 
-		return array();
+		$query = $blog->Tags();
+
+		if ($this->Limit) {
+			$query = $query->limit(Convert::raw2sql($this->Limit));
+		}
+
+		if ($this->Order && $this->Direction) {
+			$query = $query->sort(Convert::raw2sql($this->Order), Convert::raw2sql($this->Direction));
+		}
+
+		return $query;
 	}
 }
 


### PR DESCRIPTION
Adds limit, sort and direction attributes to tags and categories widgets.

https://github.com/silverstripe/silverstripe-blog/issues/281

<img width="740" alt="screen shot 2015-07-08 at 1 07 52 pm" src="https://cloud.githubusercontent.com/assets/200609/8560989/62807948-2572-11e5-8a68-9854fed7f43b.png">

<img width="740" alt="screen shot 2015-07-08 at 1 07 59 pm" src="https://cloud.githubusercontent.com/assets/200609/8560990/6481b0ae-2572-11e5-8b7d-963febb64ff3.png">
