### PR TITLE
BUG Fix canview for non-admins

### DIFF
--- a/code/model/BlogPost.php
+++ b/code/model/BlogPost.php
@@ -409,22 +409,24 @@ class BlogPost extends Page {
 	 * {@inheritdoc}
 	 */
 	public function canView($member = null) {
+		$member = $this->getMember($member);
+
 		if(!parent::canView($member)) {
 			return false;
 		}
+		
+		/**
+		 * @var SS_Datetime $publishDate
+		 */
+		$publishDate = $this->dbObject('PublishDate');
 
-		if($this->PublishDate) {
-			/**
-			 * @var SS_Datetime $publishDate
-			 */
-			$publishDate = $this->dbObject('PublishDate');
-
-			if($publishDate->InFuture() && !Permission::checkMember($member, 'VIEW_DRAFT_CONTENT')) {
-				return false;
-			}
+		// Show past posts
+		if(!$publishDate->exists() || !$publishDate->InFuture()) {
+			return true;
 		}
 
-		return true;
+		// Anyone that can edit this page can view it
+		return $this->canEdit($member);
 	}
 
 	/**

--- a/tests/BlogPostTest.php
+++ b/tests/BlogPostTest.php
@@ -1,0 +1,66 @@
+<?php
+
+class BlogPostTest extends SapphireTest {
+	
+	/**
+	 * @var string
+	 */
+	static $fixture_file = 'blog.yml';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setUp() {
+		parent::setUp();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function tearDown() {
+		SS_Datetime::clear_mock_now();
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider canViewProvider
+	 */
+	public function testCanView($date, $user, $page, $canView) {
+		$userRecord = $this->objFromFixture('Member', $user);
+		$pageRecord = $this->objFromFixture('BlogPost', $page);
+		SS_Datetime::set_mock_now($date);
+		$this->assertEquals($canView, $pageRecord->canView($userRecord));
+	}
+	
+	public function canViewProvider() {
+		$someFutureDate = '2013-10-10 20:00:00';
+		$somePastDate = '2009-10-10 20:00:00';
+		return array(
+			// Check this post given the date has passed
+			array($someFutureDate, 'Editor', 'PostA', true),
+			array($someFutureDate, 'Contributor', 'PostA', true),
+			array($someFutureDate, 'BlogEditor', 'PostA', true),
+			array($someFutureDate, 'Writer', 'PostA', true),
+			
+			// Check unpublished pages
+			array($somePastDate, 'Editor', 'PostA', true),
+			array($somePastDate, 'Contributor', 'PostA', true),
+			array($somePastDate, 'BlogEditor', 'PostA', true),
+			array($somePastDate, 'Writer', 'PostA', true),
+			
+			// Test a page that was authored by another user
+			
+			// Check this post given the date has passed
+			array($someFutureDate, 'Editor', 'FirstBlogPost', true),
+			array($someFutureDate, 'Contributor', 'FirstBlogPost', true),
+			array($someFutureDate, 'BlogEditor', 'FirstBlogPost', true),
+			array($someFutureDate, 'Writer', 'FirstBlogPost', true),
+			
+			// Check future pages - non-editors shouldn't be able to see this
+			array($somePastDate, 'Editor', 'FirstBlogPost', true),
+			array($somePastDate, 'Contributor', 'FirstBlogPost', false),
+			array($somePastDate, 'BlogEditor', 'FirstBlogPost', false),
+			array($somePastDate, 'Writer', 'FirstBlogPost', false),
+		);
+	}
+}


### PR DESCRIPTION
If a writer creates a page in the future, before this it would instantly crash the CMS.

Fixes #283