### PR TITLE
Allow injection on date

### DIFF
--- a/code/widgets/BlogArchiveWidget.php
+++ b/code/widgets/BlogArchiveWidget.php
@@ -106,7 +106,7 @@ class BlogArchiveWidget extends Widget {
 				/**
 				 * @var BlogPost $post
 				 */
-				$date = new Date();
+				$date = Date::create();
 				$date->setValue($post->PublishDate);
 
 				if($this->ArchiveType == 'Yearly') {


### PR DESCRIPTION
This change allow the use of the injector to inject another class for the date. I needed this because FormatI18N was not working as expected to localize the dates. I know it's suppose to work, but since there is no downside in allow injection, why not?