### PR TITLE
Bugfix: avoid calling "new PaginatedList(null)"

### DIFF
--- a/code/model/Blog.php
+++ b/code/model/Blog.php
@@ -962,7 +962,7 @@ class Blog_Controller extends Page_Controller {
 		 */
 		$dataRecord = $this->dataRecord;
 
-		$posts = new PaginatedList($this->blogPosts);
+		$posts = new PaginatedList($this->getBlogPosts());
 
 		if($this->PostsPerPage > 0) {
 			$posts->setPageLength($this->PostsPerPage);


### PR DESCRIPTION
/rss on a blog currently throws an error because PaginatedList gets called in the chain (somewhere within getMetaTitle) with apparently null as parameter. So if `$this->blogPosts` is null, don't go into that chain.