### PR TITLE
Sort BlogPosts in the CMS by PublishDate

### DIFF
--- a/code/extensions/BlogFilter.php
+++ b/code/extensions/BlogFilter.php
@@ -71,10 +71,10 @@ class BlogFilter extends Lumberjack {
 		$excluded = $this->owner->getExcludedSiteTreeClassNames();
 
 		if(!empty($excluded)) {
-			$pages = SiteTree::get()->filter(array(
+			$pages = BlogPost::get()->filter(array(
 				'ParentID' => $this->owner->ID,
 				'ClassName' => $excluded
-			))->sort('"SiteTree"."Created" DESC');
+			));
 
 			$gridField = new BlogFilter_GridField(
 				'ChildPages',


### PR DESCRIPTION
I don't understand why you'd want to sort by CreationDate rather than PublishDate. It feels quite counterintuitive to have the list not sorted chronologically. 

I might be missing something, but if I'm not, this is an easy fix.