### PR TITLE
i18n wrong label in BlogPost.php

### DIFF
--- a/code/model/BlogPost.php
+++ b/code/model/BlogPost.php
@@ -214,7 +214,7 @@ class BlogPost extends Page {
 				null,
 				1024
 			)->setDescription(_t(
-					'BlogPost.PublishDate_Description',
+					'BlogPost.AdditionalCredits_Description',
 					'If some authors of this post don\'t have CMS access, enter their name(s) here. You can separate multiple names with a comma.')
 			);
 


### PR DESCRIPTION
Wrong Description label for additional credits description, uses PublishDate_Description.