### PR TITLE
FIX Explicitly set the PostsPerPage during migration

### DIFF
--- a/code/compat/pages/BlogHolder.php
+++ b/code/compat/pages/BlogHolder.php
@@ -50,6 +50,7 @@ class BlogHolder extends BlogTree implements MigratableObject {
 		if($this->ClassName === 'BlogHolder') {
 			$this->ClassName = 'Blog';
 			$this->RecordClassName = 'Blog';
+			$this->PostsPerPage = 10;
 			$this->write();
 		}
 


### PR DESCRIPTION
Tested against the silverstripe.org codebase, BlogHolder migration fails unless you set this.