### PR TITLE
FIX If grant_user_access is set then return filtered list

### DIFF
--- a/code/model/Blog.php
+++ b/code/model/Blog.php
@@ -360,11 +360,11 @@ class Blog extends Page implements PermissionProvider {
 	 */
 	protected function getCandidateUsers() {
 		if($this->config()->grant_user_access) {
-			return Member::get();
-		} else {
 			return Permission::get_members_by_permission(
 				$this->config()->grant_user_permission
 			);
+		} else {
+			return Member::get();
 		}
 	}
 


### PR DESCRIPTION
I think there is a bug here in that a config value doesn't actually filter the returned Members. This causes a problem on large sites with 1000's of users as it returns them all and you often run into a out of memory problem. I should be able to set a permission value which qualifies a list of appropriate users that can manage blog roles.

Is it as simple as reversing the conditional?