### PR TITLE
BUGFIX: Blogs could not be nested under anything other than a Blog

### DIFF
--- a/code/extensions/BlogFilter.php
+++ b/code/extensions/BlogFilter.php
@@ -8,6 +8,12 @@
  * @subpackage blog
  */
 class BlogFilter extends Lumberjack {
+	public static function get_extra_config($class, $extension, $args) {
+		return array(
+			'has_one' => array('Parent' => 'SiteTree')
+		);
+	}
+	
 	/**
 	 * {@inheritdoc}
 	 */


### PR DESCRIPTION
Due to how the [Hierarchy](https://github.com/silverstripe/silverstripe-framework/blob/3.2/model/Hierarchy.php#L41-L45) class adds the has_one relationship to the parent when the blog module's BlogFilter extension is added it overrides the has_one relationship pointing it to another Blog page. Which causes the blog to be considered orphaned which in turn is preventing non-authenticated/non-cms users from being able to view the blog and it's decedents. This pull requests addresses the issue by overriding Hierarchy::get_extra_config() and forcing the Parent has_one to be set to SiteTree.