### PR TITLE
BUGFIX: Dropdowns do not use unique IDs

### DIFF
--- a/code/admin/GridFieldMergeAction.php
+++ b/code/admin/GridFieldMergeAction.php
@@ -66,7 +66,7 @@ class GridFieldMergeAction implements GridField_ColumnProvider, GridField_Action
 	public function getColumnContent($gridField, $record, $columnName) {
 		if($columnName === 'MergeAction' && $record->{$this->childMethod}()->Count() > 0) {
 			$dropdown = new DropdownField('Target', 'Target', $this->records->exclude('ID', $record->ID)->map());
-
+			$dropdown->setAttribute('id', 'Target_'.$record->ID);
 			$prefix = strtolower($this->parentMethod . '-' . $this->childMethod);
 
 			$action = GridFieldFormAction::create(


### PR DESCRIPTION
Solves problem where `DOMXPath` was throwing (in `ShortcodeParser`) due to invalid HTML