### PR TITLE
BUG Fix tag / category filters not being filtered in PaginatedList()

### DIFF
--- a/code/model/Blog.php
+++ b/code/model/Blog.php
@@ -959,27 +959,21 @@ class Blog_Controller extends Page_Controller {
 	 * @return PaginatedList
 	 */
 	public function PaginatedList() {
-		/**
-		 * @var Blog $dataRecord
-		 */
-		$dataRecord = $this->dataRecord;
+		$allPosts = $this->blogPosts ?: new ArrayList();
+		$posts = new PaginatedList($allPosts);
 
-		$posts = new PaginatedList($this->getBlogPosts());
-
+		// Set appropriate page size
 		if($this->PostsPerPage > 0) {
-			$posts->setPageLength($this->PostsPerPage);
+			$pageSize = $this->PostsPerPage;
+		} elseif($count = $allPosts->count()) {
+			$pageSize = $count;
 		} else {
 			$pageSize = 99999;
-
-			if($count = $dataRecord->getBlogPosts()->count()) {
-				$pageSize = $count;
-			}
-
-			$posts->setPageLength($pageSize);
 		}
+		$posts->setPageLength($pageSize);
 
+		// Set current page
 		$start = $this->request->getVar($posts->getPaginationGetVar());
-
 		$posts->setPageStart($start);
 
 		return $posts;
@@ -996,7 +990,9 @@ class Blog_Controller extends Page_Controller {
 		 */
 		$dataRecord = $this->dataRecord;
 
-		$rss = new RSSFeed($dataRecord->getBlogPosts(), $this->Link(), $this->MetaTitle, $this->MetaDescription);
+		$this->blogPosts = $dataRecord->getBlogPosts();
+
+		$rss = new RSSFeed($this->blogPosts, $this->Link(), $this->MetaTitle, $this->MetaDescription);
 
 		$this->extend('updateRss', $rss);
 

--- a/tests/BlogTest.php
+++ b/tests/BlogTest.php
@@ -253,4 +253,72 @@ class BlogTest extends SapphireTest {
 		$this->assertFalse($postB->canPublish($visitor));
 		$this->assertFalse($postC->canPublish($visitor));
 	}
+
+	public function testFilteredCategories() {
+		$blog = $this->objFromFixture('Blog', 'FirstBlog');
+		$controller = new Blog_Controller($blog);
+		
+		// Root url
+		$this->requestURL($controller, 'first-post');
+		$this->assertIDsEquals(
+			$blog->AllChildren()->column('ID'),
+			$controller->PaginatedList()->column('ID')
+		);
+
+
+		// RSS
+		$this->requestURL($controller, 'first-post/rss');
+		$this->assertIDsEquals(
+			$blog->AllChildren()->column('ID'),
+			$controller->PaginatedList()->column('ID')
+		);
+
+		// Posts
+		$firstPostID = $this->idFromFixture('BlogPost', 'FirstBlogPost');
+		$secondPostID = $this->idFromFixture('BlogPost', 'SecondBlogPost');
+		$firstFuturePostID = $this->idFromFixture('BlogPost', 'FirstFutureBlogPost');
+		$secondFuturePostID = $this->idFromFixture('BlogPost', 'SecondFutureBlogPost');
+
+		// Request first tag
+		$this->requestURL($controller, 'first-post/tag/first-tag');
+		$this->assertIDsEquals(
+			array($firstPostID, $firstFuturePostID, $secondFuturePostID),
+			$controller->PaginatedList()
+		);
+
+		// Request 2013 posts
+		$this->requestURL($controller, 'first-post/archive/2013');
+		$this->assertIDsEquals(
+			array($firstPostID, $secondPostID, $secondFuturePostID),
+			$controller->PaginatedList()
+		);
+	}
+
+	/**
+	 * Mock a request against a given controller
+	 *
+	 * @param ContentController $controller
+	 * @param string $url
+	 */
+	protected function requestURL(ContentController $controller, $url) {
+		$request = new SS_HTTPRequest('get', $url);
+		$request->match('$URLSegment//$Action/$ID/$OtherID');
+		$request->shift();
+		$controller->init();
+		$controller->handleRequest($request, new DataModel());
+	}
+
+	/**
+	 * Assert these id lists match
+	 *
+	 * @param array|SS_List $left
+	 * @param array|SS_List $right
+	 */
+	protected function assertIDsEquals($left, $right) {
+		if($left instanceof SS_List) $left = $left->column('ID');
+		if($right instanceof SS_List) $right = $right->column('ID');
+		asort($left);
+		asort($right);
+		$this->assertEquals(array_values($left), array_values($right));
+	}
 }


### PR DESCRIPTION
It's necessary to use $blogPosts because this is the variable that contains the pre-filtered list for the current blog, which is assigned during one of the appropriate filtering methods (category / tag / etc).