### PR TITLE
Fixing BlogPost getCMSFields bug

### DIFF
--- a/code/model/BlogPost.php
+++ b/code/model/BlogPost.php
@@ -216,7 +216,7 @@ class BlogPost extends Page
             $authorField = ListboxField::create(
                 'Authors',
                 _t('BlogPost.Authors', 'Authors'),
-                $this->getCandidateAuthors()->map()->toArray()
+                $self->getCandidateAuthors()->map()->toArray()
             )->setMultiple(true);
 
             $authorNames = TextField::create(


### PR DESCRIPTION
Fixing bug in `BlogPost` `getCMSFields` where `$this` is being called within the `beforeUpdateCMSFields` function where `$self` should be used. This is causing an error when trying to view / edit a `BlogPost` through the CMS.

This fixes issue #324