### PR TITLE
BUG Fix regression in #312 in PHP 5.3

### DIFF
--- a/code/model/BlogPost.php
+++ b/code/model/BlogPost.php
@@ -216,7 +216,7 @@ class BlogPost extends Page
             $authorField = ListboxField::create(
                 'Authors',
                 _t('BlogPost.Authors', 'Authors'),
-                $this->getCandidateAuthors()->map()->toArray()
+                $self->getCandidateAuthors()->map()->toArray()
             )->setMultiple(true);
 
             $authorNames = TextField::create(

--- a/tests/BlogPostTest.php
+++ b/tests/BlogPostTest.php
@@ -78,5 +78,9 @@ class BlogPostTest extends SapphireTest
         Config::inst()->update('BlogPost', 'restrict_authors_to_group', 'BlogUsers');
 
         $this->assertEquals(3, $blogpost->getCandidateAuthors()->count());
+
+        // Test cms field is generated
+        $fields = $blogpost->getCMSFields();
+        $this->assertNotEmpty($fields->dataFieldByName('Authors'));
     }
 }


### PR DESCRIPTION
The change in #312 used `$this` inside a closure, which wasn't tested, but failed in PHP 5.3.