### PR TITLE
Minor: Stopped messages overflowing in blog-post

### DIFF
--- a/js/cms.js
+++ b/js/cms.js
@@ -91,7 +91,7 @@
 			minInnerWidth: 620,
 			onadd: function() {
 				// Adding margin to prevent post options from overlaping message box
-				$('#Form_EditForm_error ').attr('style', 'margin-right: 56px');
+				$('#Form_EditForm_error ').css('margin-right', '56px');
 
 				this._super();
 				this.updateLayout();

--- a/js/cms.js
+++ b/js/cms.js
@@ -91,7 +91,7 @@
 			minInnerWidth: 620,
 			onadd: function() {
 				// Adding margin to prevent post options from overlaping message box
-				$('.message').attr('style', 'margin-right: 56px');
+				$('#Form_EditForm_error ').attr('style', 'margin-right: 56px');
 
 				this._super();
 				this.updateLayout();

--- a/js/cms.js
+++ b/js/cms.js
@@ -44,7 +44,7 @@
 				$this.parent().next('.description').addClass('toggle-description-correct-description');
 			}
 		});
-		
+
 		/**
 		 * Custom merge actions for tags and categories
 		 */
@@ -81,18 +81,21 @@
 				});
 			}
 		});
-		
+
 		/**
 		 * Customise the cms-panel behaviour for blog sidebar
-		 * 
+		 *
 		 * see LeftAndMain.Panel.js for base behaviour
 		 */
 		$('.blog-admin-sidebar.cms-panel').entwine({
 			minInnerWidth: 620,
 			onadd: function() {
+				// Adding margin to prevent post options from overlaping message box
+				$('.message').attr('style', 'margin-right: 56px');
+
 				this._super();
 				this.updateLayout();
-				
+
 				// If this panel is open and the left hand column is smaller than the minimum, contract it instead
 				if(!this.hasClass('collapsed') && ($(".blog-admin-outer").width() < this.getminInnerWidth())) {
 					this.collapsePanel();
@@ -104,7 +107,7 @@
 			},
 			/**
 			 * Adjust minimum width of content to account for extra panel
-			 * 
+			 *
 			 * @returns {undefined}
 			 */
 			updateLayout: function() {


### PR DESCRIPTION
added line to cms.js that adds margin to messages on the new blog post page in CMS

https://github.com/silverstripe/silverstripe-blog/issues/210

![6e4371c2-eeb8-11e4-9de1-bc9876b9faa8](https://cloud.githubusercontent.com/assets/16693158/12433994/ed68af22-bf68-11e5-80ff-46b70f76bd79.png)

![screenshot from 2016-01-20 11 29 06](https://cloud.githubusercontent.com/assets/16693158/12434047/22b6fc6a-bf69-11e5-9ee3-f509587ec0db.png)

