### PR TITLE
FIX: Tests now pass in Postgres on 3.1 and 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,18 @@ matrix:
       env: DB=MYSQL COVERAGE=1
     - php: 5.5
       env: DB=MYSQL
+    - php: 5.6
+      env: DB=PGSQL
+    - php: 5.6
+      env: DB=MYSQL CORE_RELEASE=3.2
+    - php: 5.6
+      env: DB=PGSQL CORE_RELEASE=3.2
     - php: 5.4
       env: DB=MYSQL
     - php: 5.3
       env: DB=MYSQL
     - php: hhvm
       env: DB=MYSQL
-      before_install:
 
 
 before_script:

--- a/code/extensions/URLSegmentExtension.php
+++ b/code/extensions/URLSegmentExtension.php
@@ -20,7 +20,9 @@ class URLSegmentExtension extends DataExtension
      */
     public function onBeforeWrite()
     {
-        $this->owner->generateURLSegment();
+        if ($this->owner->BlogID) {
+            $this->owner->generateURLSegment();
+        }
     }
 
     /**
@@ -38,6 +40,12 @@ class URLSegmentExtension extends DataExtension
 
         if (is_int($increment)) {
             $this->owner->URLSegment .= '-' . $increment;
+        }
+
+        // Postgres use '' instead of 0 as an emtpy blog ID
+        // Without this all the tests fail
+        if (!$this->owner->BlogID) {
+            $this->owner->BlogID = 0;
         }
 
         $duplicate = DataList::create($this->owner->ClassName)->filter(array(

--- a/code/model/BlogPost.php
+++ b/code/model/BlogPost.php
@@ -93,7 +93,7 @@ class BlogPost extends Page
 
     /**
      * The default sorting lists BlogPosts with an empty PublishDate at the top.
-     * 
+     *
      * @var string
      */
     private static $default_sort = '"PublishDate" IS NULL DESC, "PublishDate" DESC';

--- a/tests/BlogPostTest.php
+++ b/tests/BlogPostTest.php
@@ -34,7 +34,7 @@ class BlogPostTest extends SapphireTest
         SS_Datetime::set_mock_now($date);
         $this->assertEquals($canView, $pageRecord->canView($userRecord));
     }
-    
+
     public function canViewProvider()
     {
         $someFutureDate = '2013-10-10 20:00:00';
@@ -45,13 +45,13 @@ class BlogPostTest extends SapphireTest
             array($someFutureDate, 'Contributor', 'PostA', true),
             array($someFutureDate, 'BlogEditor', 'PostA', true),
             array($someFutureDate, 'Writer', 'PostA', true),
-            
+
             // Check unpublished pages
             array($somePastDate, 'Editor', 'PostA', true),
             array($somePastDate, 'Contributor', 'PostA', true),
             array($somePastDate, 'BlogEditor', 'PostA', true),
             array($somePastDate, 'Writer', 'PostA', true),
-            
+
             // Test a page that was authored by another user
 
             // Check this post given the date has passed
@@ -59,7 +59,7 @@ class BlogPostTest extends SapphireTest
             array($someFutureDate, 'Contributor', 'FirstBlogPost', true),
             array($someFutureDate, 'BlogEditor', 'FirstBlogPost', true),
             array($someFutureDate, 'Writer', 'FirstBlogPost', true),
-            
+
             // Check future pages - non-editors shouldn't be able to see this
             array($somePastDate, 'Editor', 'FirstBlogPost', true),
             array($somePastDate, 'Contributor', 'FirstBlogPost', false),
@@ -75,7 +75,7 @@ class BlogPostTest extends SapphireTest
         $this->assertEquals(7, $blogpost->getCandidateAuthors()->count());
 
         //Set the group to draw Members from
-        Config::inst()->update('BlogPost', 'restrict_authors_to_group', 'BlogUsers');
+        Config::inst()->update('BlogPost', 'restrict_authors_to_group', 'blogusers');
 
         $this->assertEquals(3, $blogpost->getCandidateAuthors()->count());
 

--- a/tests/BlogTagTest.php
+++ b/tests/BlogTagTest.php
@@ -131,4 +131,22 @@ class BlogTagTest extends FunctionalTest
         $this->assertTrue($tag->canDelete($admin), 'Admin should always be able to delete tags.');
         $this->assertTrue($tag->canDelete($editor), 'Editor should be able to delete tag.');
     }
+
+    public function testDuplicateTagsForURLSegment() {
+        $blog = new Blog();
+        $blog->Title = 'Testing for duplicates blog';
+        $blog->write();
+        $tag1 = new BlogTag();
+        $tag1->Title = 'Cat';
+        $tag1->BlogID = $blog->ID;
+        $tag1->write();
+        $this->assertEquals('cat', $tag1->URLSegment);
+
+        $tag2 = new BlogTag();
+        $tag2->Title = 'Cat';
+        $tag2->BlogID = $blog->ID;
+        $tag2->write();
+        $this->assertEquals('cat-0', $tag2->URLSegment);
+
+    }
 }


### PR DESCRIPTION
Problems resolved:
1) Case sensitivy of check on Code field of Group
2) MySQL and Postgres have different date functions
3) When BlogID is empty, explicitly set it to 0.  If not then all tests break under Postgres

Fix for https://github.com/silverstripe/silverstripe-blog/issues/361