### PR TITLE
BUG Fix blog date filtering for additional database server types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
     - php: 5.6
       env: DB=PGSQL CORE_RELEASE=3.2
     - php: 5.4
-      env: DB=MYSQL
+      env: DB=SQLITE
     - php: 5.3
       env: DB=MYSQL
     - php: hhvm

--- a/code/model/Blog.php
+++ b/code/model/Blog.php
@@ -473,35 +473,21 @@ class Blog extends Page implements PermissionProvider
 
         $query->innerJoin('BlogPost', sprintf('"SiteTree%s"."ID" = "BlogPost%s"."ID"', $stage, $stage));
 
-        // getConn is deprecated, but not get_conn in 3.1
-        $getConnectionMethod = 'getConn';
-        if (method_exists('DB','get_conn')) {
-            $getConnectionMethod = 'get_conn';
-        };
+        $conn = DB::getConn();
 
+        // Filter by year
+        $yearCond = $conn->formattedDatetimeClause('"BlogPost"."PublishDate"', '%Y');
+        $query->where(sprintf('%s = \'%04d\'', $yearCond, Convert::raw2sql($year)));
 
-        if (DB::$getConnectionMethod() instanceof MySQLDatabase) {
-            $query->where(sprintf('YEAR("PublishDate") = \'%s\'', Convert::raw2sql($year)));
+        // Filter by month (if given)
+        if ($month) {
+            $monthCond = $conn->formattedDatetimeClause('"BlogPost"."PublishDate"', '%m');
+            $query->where(sprintf('%s = \'%02d\'', $monthCond, Convert::raw2sql($month)));
 
-            if ($month) {
-                $query->where(sprintf('MONTH("PublishDate") = \'%s\'', Convert::raw2sql($month)));
-
-                if ($day) {
-                    $query->where(sprintf('DAY("PublishDate") = \'%s\'', Convert::raw2sql($day)));
-                }
+            if ($day) {
+                $dayCond = $conn->formattedDatetimeClause('"BlogPost"."PublishDate"', '%d');
+                $query->where(sprintf('%s = \'%02d\'', $dayCond, Convert::raw2sql($day)));
             }
-        } elseif (DB::$getConnectionMethod() instanceof PostgreSQLDatabase) {
-            $where = sprintf('EXTRACT(YEAR FROM "PublishDate") = \'%s\'', Convert::raw2sql($year));
-
-            if ($month) {
-                $where .= sprintf(' AND EXTRACT(MONTH FROM "PublishDate") = \'%s\'', Convert::raw2sql($month));
-
-                if ($day) {
-                    $where .= sprintf(' AND EXTRACT(DAY FROM "PublishDate") = \'%s\'', Convert::raw2sql($day));
-                }
-            }
-
-            $query->where($where);
         }
 
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 	],
 	"type": "silverstripe-module",
 	"require": {
-		"silverstripe/cms": ">=3.1.0",
+		"silverstripe/cms": "^3.1.0",
 		"silverstripe/lumberjack": "~1.1",
 		"silverstripe/tagfield": "^1.0"
 	},

--- a/tests/blog.yml
+++ b/tests/blog.yml
@@ -7,7 +7,7 @@ Group:
     Title: Editors
   BlogUsers:
     Title: Blog Users
-    Code: BlogUsers
+    Code: blogusers
 
 Permission:
   Administrators:


### PR DESCRIPTION
I've also locked this to the 3.x major version to prevent semver regressions in master.

To that extend, it's safe to use DB::getConn(), as it's not going to be removed until 4.0.0.