### PR TITLE
FIX: Missing Blog Post Title from Comment Notification

### DIFF
--- a/code/extensions/BlogPostNotifications.php
+++ b/code/extensions/BlogPostNotifications.php
@@ -27,6 +27,6 @@ class BlogPostNotifications extends DataExtension
      */
     public function updateNotificationSubject(&$subject, &$comment, &$recipient)
     {
-        $subject = sprintf('A new comment has been posted on ', $this->owner->Title);
+        $subject = sprintf('A new comment has been posted on %s', $this->owner->Title);
     }
 }

--- a/tests/BlogPostNotificationsTest.php
+++ b/tests/BlogPostNotificationsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+class BlogPostNotificationsTest extends SapphireTest
+{
+    /**
+     * @var string
+     */
+    public static $fixture_file = 'blog.yml';
+
+    public function testUpdateNotificationRecipients()
+    {
+        if (!class_exists('CommentNotifier')) {
+            $this->markTestSkipped('Comments Notification module is not installed');
+        }
+
+        $blogPost = $this->objFromFixture('BlogPost', 'PostC');
+        $comment = new Comment();
+        $comment->Comment = 'This is a comment';
+        $comment->write();
+        $recipients = $blogPost->notificationRecipients(
+            $comment
+        )->toArray();
+
+        $segments = array();
+        foreach ($recipients as $recipient) {
+            array_push($segments, $recipient->URLSegment);
+        }
+
+        sort($segments);
+        $this->assertEquals(array('blog-contributor', 'blog-editor',
+                                    'blog-writer', ), $segments);
+    }
+
+    public function testUpdateNotificationSubject()
+    {
+        if (!class_exists('CommentNotifier')) {
+            $this->markTestSkipped('Comments Notification module is not installed');
+        }
+        $blogPost = $this->objFromFixture('BlogPost', 'PostC');
+        $comment = new Comment();
+        $comment->Comment = 'This is a comment';
+        $comment->write();
+        $recipients = $blogPost->notificationRecipients(
+            $comment
+        )->toArray();
+        $subject = $blogPost->notificationSubject($comment, $recipients[0]);
+        $this->assertEquals(
+            'A new comment has been posted on Third Post',
+            $subject
+        );
+    }
+}


### PR DESCRIPTION
Fix for https://github.com/silverstripe/silverstripe-blog/issues/364