### PR TITLE
FIX Prevent the CMS Hijacking the return keypress in gridfieldaddbydb…

### DIFF
--- a/code/forms/gridfield/GridFieldAddByDBField.php
+++ b/code/forms/gridfield/GridFieldAddByDBField.php
@@ -147,6 +147,8 @@ class GridFieldAddByDBField implements GridField_ActionProvider, GridField_HTMLP
      */
     public function getHTMLFragments($gridField)
     {
+        Requirements::javascript(BLOGGER_DIR . '/js/gridfieldaddbydbfield.js');
+
         /**
          * @var DataList $dataList
          */
@@ -184,7 +186,6 @@ class GridFieldAddByDBField implements GridField_ActionProvider, GridField_HTMLP
             'add',
             'add'
         );
-
         $addAction->setAttribute('data-icon', 'add');
 
         $forTemplate = new ArrayData(array());

--- a/js/gridfieldaddbydbfield.js
+++ b/js/gridfieldaddbydbfield.js
@@ -1,0 +1,20 @@
+(function ($) {
+
+    $.entwine('ss', function ($) {
+
+        /**
+         * Prevent the CMS hijacking the return key
+         */
+        $('.add-existing-autocompleter input.text').entwine({
+            'onkeydown': function (e) {
+                if(e.which == 13) {
+                    $parent = $(this).parents('.add-existing-autocompleter');
+                    $parent.find('button[type="submit"]').click();
+                    return false;
+                }
+            }
+        });
+
+    });
+
+})(jQuery);


### PR DESCRIPTION
…field

This fixes #266

I believe https://github.com/silverstripe/silverstripe-framework/issues/3181 is related, but the framework doesn't allow `->setAttribute('type', 'button')` on `FormAction` or `GridField_FormAction` in this case..