### PR TITLE
Add RSS feeds for categories and tags

### DIFF
--- a/code/model/Blog.php
+++ b/code/model/Blog.php
@@ -644,8 +644,8 @@ class Blog_Controller extends Page_Controller
      * @var array
      */
     private static $url_handlers = array(
-        'tag/$Tag!' => 'tag',
-        'category/$Category!' => 'category',
+        'tag/$Tag!/$Rss' => 'tag',
+        'category/$Category!/$Rss' => 'category',
         'archive/$Year!/$Month/$Day' => 'archive',
         'profile/$URLSegment!' => 'profile',
     );
@@ -834,7 +834,12 @@ class Blog_Controller extends Page_Controller
 
         if ($tag) {
             $this->blogPosts = $tag->BlogPosts();
-            return $this->render();
+
+            if($this->isRSS()) {
+            	return $this->rssFeed($this->blogPosts);
+            } else {
+            	return $this->render();
+            }
         }
 
         $this->httpError(404, 'Not Found');
@@ -874,7 +879,11 @@ class Blog_Controller extends Page_Controller
         if ($category) {
             $this->blogPosts = $category->BlogPosts();
 
-            return $this->render();
+            if($this->isRSS()) {
+            	return $this->rssFeed($this->blogPosts);
+            } else {
+            	return $this->render();
+            }
         }
 
         $this->httpError(404, 'Not Found');
@@ -1049,11 +1058,7 @@ class Blog_Controller extends Page_Controller
 
         $this->blogPosts = $dataRecord->getBlogPosts();
 
-        $rss = new RSSFeed($this->blogPosts, $this->Link(), $this->MetaTitle, $this->MetaDescription);
-
-        $this->extend('updateRss', $rss);
-
-        return $rss->outputToBrowser();
+        return $this->rssFeed($this->blogPosts);
     }
 
     /**
@@ -1093,4 +1098,30 @@ class Blog_Controller extends Page_Controller
     {
         return $this->Link('rss');
     }
+    
+    /**
+     * Displays an RSS feed of the given blog posts.
+     *
+     * @return string
+     */
+    public function rssFeed($blogPosts)
+    {
+        $rss = new RSSFeed($blogPosts, $this->Link() . 'category/general/', $this->MetaTitle, $this->MetaDescription);
+
+        $this->extend('updateRss', $rss);
+
+        return $rss->outputToBrowser();
+    }
+    
+    /** 
+     * Returns true if the $Rss sub-action for categories/tags has been set to "rss"
+     */
+     private function isRSS() {
+     	 $rss = $this->request->param('Rss');
+     	 if($rss && strcasecmp($rss, "rss") == 0) {
+     	 	 return true;
+     	 } else {
+     	 	 return false;
+     	 }
+     }
 }

--- a/code/model/Blog.php
+++ b/code/model/Blog.php
@@ -826,7 +826,7 @@ class Blog_Controller extends Page_Controller
     /**
      * Renders the blog posts for a given tag.
      *
-     * @return null|SS_HTTPResponse|string
+     * @return null|SS_HTTPResponse
      */
     public function tag()
     {
@@ -870,7 +870,7 @@ class Blog_Controller extends Page_Controller
     /**
      * Renders the blog posts for a given category.
      *
-     * @return null|SS_HTTPResponse|string
+     * @return null|SS_HTTPResponse
      */
     public function category()
     {

--- a/code/model/Blog.php
+++ b/code/model/Blog.php
@@ -826,7 +826,7 @@ class Blog_Controller extends Page_Controller
     /**
      * Renders the blog posts for a given tag.
      *
-     * @return null|SS_HTTPResponse
+     * @return null|SS_HTTPResponse|string
      */
     public function tag()
     {
@@ -836,7 +836,7 @@ class Blog_Controller extends Page_Controller
             $this->blogPosts = $tag->BlogPosts();
 
             if($this->isRSS()) {
-            	return $this->rssFeed($this->blogPosts);
+            	return $this->rssFeed($this->blogPosts, $tag->getLink());
             } else {
             	return $this->render();
             }
@@ -870,7 +870,7 @@ class Blog_Controller extends Page_Controller
     /**
      * Renders the blog posts for a given category.
      *
-     * @return null|SS_HTTPResponse
+     * @return null|SS_HTTPResponse|string
      */
     public function category()
     {
@@ -880,7 +880,7 @@ class Blog_Controller extends Page_Controller
             $this->blogPosts = $category->BlogPosts();
 
             if($this->isRSS()) {
-            	return $this->rssFeed($this->blogPosts);
+            	return $this->rssFeed($this->blogPosts, $category->getLink());
             } else {
             	return $this->render();
             }
@@ -1058,7 +1058,7 @@ class Blog_Controller extends Page_Controller
 
         $this->blogPosts = $dataRecord->getBlogPosts();
 
-        return $this->rssFeed($this->blogPosts);
+        return $this->rssFeed($this->blogPosts, $this->Link());
     }
 
     /**
@@ -1102,11 +1102,14 @@ class Blog_Controller extends Page_Controller
     /**
      * Displays an RSS feed of the given blog posts.
      *
+     * @param DataList $blogPosts
+     * @param string $link
+     *
      * @return string
      */
-    protected function rssFeed($blogPosts)
+    protected function rssFeed($blogPosts, $link)
     {
-        $rss = new RSSFeed($blogPosts, $this->Link(), $this->MetaTitle, $this->MetaDescription);
+        $rss = new RSSFeed($blogPosts, $link, $this->MetaTitle, $this->MetaDescription);
 
         $this->extend('updateRss', $rss);
 

--- a/code/model/Blog.php
+++ b/code/model/Blog.php
@@ -1119,13 +1119,13 @@ class Blog_Controller extends Page_Controller
     /** 
      * Returns true if the $Rss sub-action for categories/tags has been set to "rss"
      */
-     private function isRSS() 
-     {
-     	 $rss = $this->request->param('Rss');
-     	 if(is_string($rss) && strcasecmp($rss, "rss") == 0) {
-     	 	 return true;
-     	 } else {
-     	 	 return false;
-     	 }
-     }
+    private function isRSS() 
+    {
+        $rss = $this->request->param('Rss');
+        if(is_string($rss) && strcasecmp($rss, "rss") == 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 }

--- a/code/model/Blog.php
+++ b/code/model/Blog.php
@@ -1104,9 +1104,9 @@ class Blog_Controller extends Page_Controller
      *
      * @return string
      */
-    public function rssFeed($blogPosts)
+    protected function rssFeed($blogPosts)
     {
-        $rss = new RSSFeed($blogPosts, $this->Link() . 'category/general/', $this->MetaTitle, $this->MetaDescription);
+        $rss = new RSSFeed($blogPosts, $this->Link(), $this->MetaTitle, $this->MetaDescription);
 
         $this->extend('updateRss', $rss);
 
@@ -1116,9 +1116,10 @@ class Blog_Controller extends Page_Controller
     /** 
      * Returns true if the $Rss sub-action for categories/tags has been set to "rss"
      */
-     private function isRSS() {
+     private function isRSS() 
+     {
      	 $rss = $this->request->param('Rss');
-     	 if($rss && strcasecmp($rss, "rss") == 0) {
+     	 if(is_string($rss) && strcasecmp($rss, "rss") == 0) {
      	 	 return true;
      	 } else {
      	 	 return false;


### PR DESCRIPTION
This patch adds RSS feeds for tags and categories (for issue #382). The RSS feeds are at the following URLs:
- */category/<category-name>/rss
- */tag/<tag-name>/rss