### PR TITLE
FIX Cast Date method on BlogPost

### DIFF
--- a/code/model/BlogPost.php
+++ b/code/model/BlogPost.php
@@ -84,6 +84,7 @@ class BlogPost extends Page
      */
     private static $casting = array(
         'Excerpt' => 'Text',
+        'Date' => 'SS_Datetime',
     );
 
     /**


### PR DESCRIPTION
Fixes an issue where the RSS feed date is not populated due to no casting helper on `getDate`

This will need a new patch release when merged