### PR TITLE
setValue on lazy dbObjects

### DIFF
--- a/src/Model/BlogPost.php
+++ b/src/Model/BlogPost.php
@@ -501,6 +501,8 @@ class BlogPost extends Page
          * @var DBDatetime $publishDate
          */
         $publishDate = $this->dbObject('PublishDate');
+        $publishDate->setValue($this->PublishDate);
+
         if (!$publishDate->exists()) {
             return false;
         }
@@ -600,6 +602,7 @@ class BlogPost extends Page
          * @var DBDatetime $date
          */
         $date = $this->dbObject('PublishDate');
+        $date->setValue($this->PublishDate);
 
         if ($type != 'year') {
             if ($type == 'day') {
@@ -628,6 +631,7 @@ class BlogPost extends Page
          * @var DBDatetime $date
          */
         $date = $this->dbObject('PublishDate');
+        $date->setValue($this->PublishDate);
 
         return Controller::join_links($this->Parent()->Link('archive'), $date->format('Y'));
     }


### PR DESCRIPTION
Currently, unless you are logged in you can't see a BlogPost. This is because `$this->dbObject('PublishDate')` doesn't auto-populate the value, as it picks up `PublishDate_Lazy` instead of `PublishDate`.

This change sets the value explicitly to ensure that setting view permissions works as expected.