### PR TITLE
BlogMigrationTask missing title and description

### DIFF
--- a/code/compat/tasks/BlogMigrationTask.php
+++ b/code/compat/tasks/BlogMigrationTask.php
@@ -2,6 +2,9 @@
 
 class BlogMigrationTask extends MigrationTask
 {
+	protected $title = "Legacy blog migration to 2.x task";
+	protected $description = "Provide atomic database changes (not implemented yet)";
+
     /**
      * Should this task be invoked automatically via dev/build?
      *


### PR DESCRIPTION
Otherwise shows up in dev/tasks/ as "Database Migrations"