### PR TITLE
Config spam notifications

### DIFF
--- a/code/extensions/BlogPostNotifications.php
+++ b/code/extensions/BlogPostNotifications.php
@@ -8,6 +8,12 @@
 class BlogPostNotifications extends DataExtension
 {
     /**
+     * Configure whether to send notifications even for spam comments
+     * @config
+     */
+    private static $notification_on_spam = true;
+
+    /**
      * Notify all authors of notifications.
      *
      * @param SS_List $list
@@ -15,7 +21,13 @@ class BlogPostNotifications extends DataExtension
      */
     public function updateNotificationRecipients(&$list, &$comment)
     {
+        //default is notification is on regardless of spam status
         $list = $this->owner->Authors();
+
+        // If comment is spam and notification are set to not send on spam clear the recipient list
+        if (Config::inst()->get(__CLASS__, 'notification_on_spam') == false && $comment->IsSpam) {
+            $list = array();
+        }
     }
 
     /**

--- a/docs/en/configuring-notifications.md
+++ b/docs/en/configuring-notifications.md
@@ -1,0 +1,15 @@
+# Configuring notifications
+
+## Configuring whether notifications will send to authors of blogs if comments are spam
+
+Default behaviour using the `silverstripe/comment-notifications` module is to send notification to authors of comments occuring regardless if they are spam or not.
+
+In some cases you may wish to not send a notification email to an author if the comment is spam, this is a configurable option.
+
+Add the following into your yaml config:
+
+```
+BlogPostNotifications:
+  notification_on_spam: false
+```
+


### PR DESCRIPTION
Allows dev to set whether a notification gets sent out to author if the comment is spam.