### PR TITLE
FIX Encode URLSegment to support multibyte member profile URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 sudo: false
 
+dist: precise
+
 addons:
   apt:
     packages:

--- a/code/extensions/BlogMemberExtension.php
+++ b/code/extensions/BlogMemberExtension.php
@@ -12,7 +12,7 @@ class BlogMemberExtension extends DataExtension
      * @var array
      */
     private static $db = array(
-        'URLSegment' => 'Varchar',
+        'URLSegment' => 'Varchar(255)',
         'BlogProfileSummary' => 'Text',
     );
 

--- a/code/model/Blog.php
+++ b/code/model/Blog.php
@@ -708,8 +708,10 @@ class Blog_Controller extends Page_Controller
         $urlSegment = $this->request->param('URLSegment');
 
         if ($urlSegment) {
+            $filter = URLSegmentFilter::create();
+
             return Member::get()
-                ->filter('URLSegment', $urlSegment)
+                ->filter('URLSegment', $filter->filter($urlSegment))
                 ->first();
         }
 
@@ -860,8 +862,10 @@ class Blog_Controller extends Page_Controller
         $dataRecord = $this->dataRecord;
         $tag = $this->request->param('Tag');
         if ($tag) {
+            $filter = URLSegmentFilter::create();
+
             return $dataRecord->Tags()
-                ->filter('URLSegment', array($tag, rawurlencode($tag)))
+                ->filter('URLSegment', array($tag, $filter->filter($tag)))
                 ->first();
         }
         return null;
@@ -904,8 +908,10 @@ class Blog_Controller extends Page_Controller
         $dataRecord = $this->dataRecord;
         $category = $this->request->param('Category');
         if ($category) {
+            $filter = URLSegmentFilter::create();
+
             return $dataRecord->Categories()
-                ->filter('URLSegment', array($category, rawurlencode($category)))
+                ->filter('URLSegment', array($category, $filter->filter($category)))
                 ->first();
         }
         return null;
@@ -1098,7 +1104,7 @@ class Blog_Controller extends Page_Controller
     {
         return $this->Link('rss');
     }
-    
+
     /**
      * Displays an RSS feed of the given blog posts.
      *
@@ -1115,11 +1121,11 @@ class Blog_Controller extends Page_Controller
 
         return $rss->outputToBrowser();
     }
-    
-    /** 
+
+    /**
      * Returns true if the $Rss sub-action for categories/tags has been set to "rss"
      */
-    private function isRSS() 
+    private function isRSS()
     {
         $rss = $this->request->param('Rss');
         if(is_string($rss) && strcasecmp($rss, "rss") == 0) {

--- a/tests/BlogFunctionalTest.php
+++ b/tests/BlogFunctionalTest.php
@@ -1,0 +1,40 @@
+<?php
+
+class BlogFunctionalTest extends FunctionalTest
+{
+    protected static $fixture_file = 'BlogFunctionalTest.yml';
+
+    protected static $use_draft_site = true;
+
+    public function setUp()
+    {
+        Config::inst()->update('URLSegmentFilter', 'default_allow_multibyte', true);
+
+        parent::setUp();
+
+        i18n::set_locale('fa_IR');
+    }
+
+    public function testBlogWithMultibyteUrl()
+    {
+        $result = $this->get('آبید');
+
+        $this->assertEquals(200, $result->getStatusCode());
+    }
+
+    public function testMemberProfileWithMultibyteUrlAndName()
+    {
+        $result = $this->get('آبید/profile/عبّاس-آبان');
+
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertContains('My Blog Post', $result->getBody());
+    }
+
+    public function testMemberProfileWithMultibyteUrlAndEnglishName()
+    {
+        $result = $this->get('آبید/profile/bob-jones');
+
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertContains('My Blog Post', $result->getBody());
+    }
+}

--- a/tests/BlogFunctionalTest.yml
+++ b/tests/BlogFunctionalTest.yml
@@ -1,0 +1,22 @@
+Member:
+  member_a:
+    FirstName: عبّاس
+    Surname: آبان
+    Email: foo@example.com
+  member_b:
+    FirstName: Bob
+    Surname: Jones
+    Email: bobjones@example.com
+
+Blog:
+  blog_a:
+    URLSegment: آبید
+    Title: My Blog
+
+BlogPost:
+  blogpost_a:
+    Title: My Blog Post
+    URLSegment: آبیدآبید
+    PublishDate: '2017-08-01 00:00:00'
+    Parent: =>Blog.blog_a
+    Authors: =>Member.member_a, =>Member.member_b


### PR DESCRIPTION
This changes:

* The length of the URLSegment DB column, since 50 characters is not enough and some encoded URLSegments were being truncated
* Encodes URLSegments before looking up Members by them

Fixes #465 
