### PR TITLE
FIX Blog user settings help links displayed incorrectly

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,0 +1,25 @@
+require 'compass/import-once/activate'
+# Require any additional compass plugins here.
+
+# Set this to the root of your project when deployed:
+http_path = "/"
+css_dir = "css"
+sass_dir = "scss"
+images_dir = "images"
+javascripts_dir = "javascripts"
+
+# You can select your preferred output style here (can be overridden via the command line):
+output_style = :nested
+
+# To enable relative paths to assets via compass helper functions. Uncomment:
+# relative_assets = true
+
+# To disable debugging comments that display the original location of your selectors. Uncomment:
+line_comments = false
+
+
+# If you prefer the indented syntax, you might want to regenerate this
+# project again passing --syntax sass, or you can uncomment this:
+# preferred_syntax = :sass
+# and then run:
+# sass-convert -R --from scss --to sass sass scss && rm -rf sass && mv scss sass

--- a/css/cms.css
+++ b/css/cms.css
@@ -74,16 +74,18 @@
   background: url("../images/information.png") no-repeat center center;
   width: 20px;
   height: 20px;
-  margin-left: 4px; }
+  margin-left: 4px;
+  cursor:pointer; }
 
 .middleColumn.toggle-description-correct-middle {
   margin-left: 0;
   float: left;
   width: 416px; }
 
-label.right.toggle-description-correct-right {
+.tab-content .field p.toggle-description-correct-right {
   display: inline-block;
   margin-left: 0;
+  padding-left: 0;
   clear: none;
   float: left; }
 

--- a/css/cms.css
+++ b/css/cms.css
@@ -75,7 +75,7 @@
   width: 20px;
   height: 20px;
   margin-left: 4px;
-  cursor:pointer; }
+  cursor: pointer; }
 
 .middleColumn.toggle-description-correct-middle {
   margin-left: 0;
@@ -95,11 +95,9 @@
 
 .custom-summary .ui-accordion-content .field {
   margin: 0; }
-
 .custom-summary .ui-accordion-content,
 .custom-summary .ui-accordion-content .field {
   padding: 0; }
-
 .custom-summary .ui-icon-triangle-1-e {
   background-position: -16px -128px; }
 
@@ -118,10 +116,8 @@
 
 .blog-cms-categorisation .MergeActionReveal {
   margin-left: 10px; }
-
 .blog-cms-categorisation .toolbar--content {
   margin-top: 0; }
-
 .blog-cms-categorisation .MergeActionReveal:after {
   content: '';
   background: url("../images/move-icon.png");
@@ -129,6 +125,5 @@
   height: 16px;
   width: 16px;
   margin-left: 4px; }
-
 .blog-cms-categorisation button.action {
   margin-left: 5px; }

--- a/js/cms.js
+++ b/js/cms.js
@@ -38,19 +38,18 @@
                  * Toggle next description when button is clicked.
                  */
                 var shown = false;
+                var $helpInfo = $this.closest('.field').find('.form-text');
 
                 $this.on('click', function () {
-                    $this.parent().next('.description')[shown ? 'hide' : 'show']();
-
+                    $helpInfo[shown ? 'hide' : 'show']();
                     $this.toggleClass('toggle-description-shown');
-
                     shown = !shown;
                 });
 
                 /**
                  * Hide next description by default.
                  */
-                $this.parent().next('.description').hide();
+                $helpInfo.hide();
 
                 /**
                  * Add classes to correct inherited layout issues in a small context.

--- a/scss/cms.scss
+++ b/scss/cms.scss
@@ -128,6 +128,7 @@
     width: 20px;
     height: 20px;
     margin-left: 4px;
+    cursor:pointer;
 }
 
 .middleColumn.toggle-description-correct-middle {
@@ -136,9 +137,10 @@
     width: 416px;
 }
 
-label.right.toggle-description-correct-right {
+.tab-content .field p.toggle-description-correct-right {
     display: inline-block;
     margin-left: 0;
+    padding-left: 0;
     clear: none;
     float: left;
 }


### PR DESCRIPTION
Fixes #474 

* Removes the raw HTML and restores the toggle functionality.
* Makes help text tranlatable
* Minimal styling changes
![image](https://user-images.githubusercontent.com/10938392/30724237-c1d056c6-9f90-11e7-8c17-46619b21629c.png)
