### PR TITLE
FIX Archive widget shows months from posts published that day

### DIFF
--- a/code/widgets/BlogArchiveWidget.php
+++ b/code/widgets/BlogArchiveWidget.php
@@ -100,18 +100,18 @@ class BlogArchiveWidget extends Widget
         $query = SQLSelect::create($fields, '"BlogPost' . $suffix . '"')
             ->addGroupBy($publishDate)
             ->addOrderBy('"PublishDate" DESC')
-            ->addWhere(array('"PublishDate" < ?' => SS_Datetime::now()->Format('Y-m-d')));
+            ->addWhere(array('"PublishDate" <= ?' => SS_Datetime::now()->Format('Y-m-d H:i:s')));
 
         $posts = $query->execute();
         $result = new ArrayList();
-        while ($next = $posts->next()) {
+        foreach ($posts as $post) {
             if ($this->ArchiveType == 'Yearly') {
-                $year  = $next['PublishDate'];
+                $year  = $post['PublishDate'];
                 $month = null;
                 $title = $year;
             } else {
                 $date = Date::create();
-                $date->setValue(strtotime($next['PublishDate']));
+                $date->setValue(strtotime($post['PublishDate']));
 
                 $year  = $date->Format('Y');
                 $month = $date->Format('m');

--- a/tests/Widgets/BlogArchiveWidgetTest.php
+++ b/tests/Widgets/BlogArchiveWidgetTest.php
@@ -12,7 +12,7 @@ class BlogArchiveWidgetTest extends SapphireTest
             $this->markTestSkipped('Test requires silverstripe/widgets to be installed.');
         }
 
-        SS_Datetime::set_mock_now('2017-09-20 00:00:00');
+        SS_Datetime::set_mock_now('2017-09-20 12:00:00');
 
         parent::setUp();
     }
@@ -67,5 +67,30 @@ class BlogArchiveWidgetTest extends SapphireTest
             array('Title' => '2017'),
             array('Title' => '2015'),
         ), $archive);
+    }
+
+    public function testArchiveMonthlyWithNewPostsAdded()
+    {
+        $original = Versioned::current_stage();
+        Versioned::reading_stage('Stage');
+
+        $widget = $this->objFromFixture('BlogArchiveWidget', 'archive-monthly');
+        $archive = $widget->getArchive();
+
+        $this->assertCount(3, $archive, 'Three months are shown in the blog archive list from fixtures');
+
+        SS_Datetime::set_mock_now('2018-01-01 12:00:00');
+
+        $newPost = new BlogPost;
+        $newPost->ParentID = $this->objFromFixture('Blog', 'my-blog')->ID;
+        $newPost->Title = 'My new blog post';
+        $newPost->PublishDate = '2018-01-01 08:00:00'; // Same day as the mocked now, but slightly earlier
+        $newPost->write();
+
+        $archive = $widget->getArchive();
+
+        $this->assertCount(4, $archive, 'Four months are shown in the blog archive list after new post added');
+
+        Versioned::reading_stage($original);
     }
 }


### PR DESCRIPTION
Finally fixes #464 

If a new blog post is published and is the only post on that day, the archive widget set to show Monthly will not show a month entry for that month, because the condition is looking for posts published before today.

I've changed it to show before or equal to today and included the time as well as the date.