### PR TITLE
FIX convert CI bootstrap references to new their new locations in vendor

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="cms/tests/bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
     <testsuite name="blog">
         <directory>tests/</directory>
     </testsuite>


### PR DESCRIPTION
Following on from the move yesterday to host SilverStripe core (4.0+) from `vendor` and in the future from outside the webroot, the according adjustments are being made to all the CI and unit testing bootstrapping files in SilverStripe's supported & most commonly used modules to allow automated tests to continue passing.