### PR TITLE
Allow a user to disable all profiles

### DIFF
--- a/docs/en/configuring-user-profiles.md
+++ b/docs/en/configuring-user-profiles.md
@@ -1,0 +1,12 @@
+## Configuring user profiles
+
+This module ships with User Profiles enabled by default.
+
+If you'd prefer to disable this functionality and instead return a 404 for the `/profile/` page, you can do so using SilverStripe config.
+
+In mysite/_config/settings.yml
+
+```yaml
+SilverStripe\Blog\Model\BlogController:
+  disable_profiles: true
+```

--- a/src/Model/BlogController.php
+++ b/src/Model/BlogController.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Blog\Model;
 
 use PageController;
 use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Control\RSS\RSSFeed;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataList;
@@ -44,6 +45,14 @@ class BlogController extends PageController
     ];
 
     /**
+     * If enabled, blog author profiles will be turned off for this site
+     *
+     * @config
+     * @var bool
+     */
+    private static $disable_profiles = false;
+
+    /**
      * The current Blog Post DataList query.
      *
      * @var DataList
@@ -68,10 +77,16 @@ class BlogController extends PageController
     /**
      * Renders a Blog Member's profile.
      *
+     * @throws HTTPResponse_Exception
+     *
      * @return string
      */
     public function profile()
     {
+        if ($this->config()->get('disable_profiles')) {
+            $this->httpError(404, 'Not Found');
+        }
+
         $profile = $this->getCurrentProfile();
 
         if (!$profile) {

--- a/src/Model/BlogController.php
+++ b/src/Model/BlogController.php
@@ -6,6 +6,7 @@ use PageController;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\RSS\RSSFeed;
 use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\PaginatedList;
 use SilverStripe\Security\Member;
@@ -67,7 +68,7 @@ class BlogController extends PageController
     /**
      * Renders a Blog Member's profile.
      *
-     * @return HTTPResponse
+     * @return string
      */
     public function profile()
     {
@@ -121,7 +122,7 @@ class BlogController extends PageController
     /**
      * Renders an archive for a specified date. This can be by year or year/month.
      *
-     * @return null|HTTPResponse
+     * @return null|string
      */
     public function archive()
     {
@@ -212,7 +213,7 @@ class BlogController extends PageController
     /**
      * Renders the blog posts for a given tag.
      *
-     * @return null|HTTPResponse
+     * @return null|string
      */
     public function tag()
     {
@@ -258,7 +259,7 @@ class BlogController extends PageController
     /**
      * Renders the blog posts for a given category.
      *
-     * @return null|HTTPResponse
+     * @return null|string
      */
     public function category()
     {
@@ -440,7 +441,7 @@ class BlogController extends PageController
      *
      * @example "<% if $PaginationAbsoluteNextLink %><link rel="next" href="$PaginationAbsoluteNextLink"><% end_if %>"
      *
-     * @return string
+     * @return string|null
      */
     public function PaginationAbsoluteNextLink()
     {
@@ -448,6 +449,8 @@ class BlogController extends PageController
         if ($posts->NotLastPage()) {
             return Director::absoluteURL($posts->NextLink());
         }
+
+        return null;
     }
 
      /**
@@ -456,7 +459,7 @@ class BlogController extends PageController
      *
      * @example "<% if $PaginationAbsolutePrevLink %><link rel="prev" href="$PaginationAbsolutePrevLink"><% end_if %>"
      *
-     * @return string
+     * @return string|null
      */
     public function PaginationAbsolutePrevLink()
     {
@@ -464,6 +467,8 @@ class BlogController extends PageController
         if ($posts->NotFirstPage()) {
             return Director::absoluteURL($posts->PrevLink());
         }
+
+        return null;
     }
 
     /**
@@ -486,7 +491,7 @@ class BlogController extends PageController
     /**
      * Returns the current archive date.
      *
-     * @return null|Date
+     * @return null|DBDatetime
      */
     public function getArchiveDate()
     {

--- a/src/Model/BlogPost.php
+++ b/src/Model/BlogPost.php
@@ -9,6 +9,7 @@ use SilverStripe\Blog\Model\BlogCategory;
 use SilverStripe\Blog\Model\BlogPostFilter;
 use SilverStripe\Blog\Model\BlogTag;
 use SilverStripe\Control\Controller;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Forms\DatetimeField;
 use SilverStripe\Forms\HiddenField;
@@ -710,6 +711,16 @@ class BlogPost extends Page
         }
 
         return $items;
+    }
+
+    /**
+     * Checks to see if User Profiles has been disabled via config
+     *
+     * @return bool
+     */
+    public function getProfilesDisabled()
+    {
+        return Config::inst()->get(BlogController::class, 'disable_profiles');
     }
 
     /**

--- a/templates/SilverStripe/Blog/Includes/EntryMeta.ss
+++ b/templates/SilverStripe/Blog/Includes/EntryMeta.ss
@@ -29,7 +29,7 @@
         <% loop $Credits %>
             <% if not $First && not $Last %>, <% end_if %>
             <% if not $First && $Last %> <%t SilverStripe\\Blog\\Model\\Blog.AND "and" %> <% end_if %>
-            <% if $URLSegment %>
+            <% if $URLSegment && not $Up.ProfilesDisabled %>
                 <a href="$URL">$Name.XML</a>
             <% else %>
                 $Name.XML

--- a/tests/BlogTest.php
+++ b/tests/BlogTest.php
@@ -9,6 +9,7 @@ use SilverStripe\CMS\Controllers\ContentController;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Control\Session;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
@@ -346,6 +347,21 @@ class BlogTest extends SapphireTest
             [$firstPostID, $secondPostID, $secondFuturePostID],
             $controller->PaginatedList()
         );
+    }
+
+    public function testDisabledProfiles()
+    {
+        Config::modify()->set(BlogController::class, 'disable_profiles', true);
+
+        try {
+            $controller = BlogController::create();
+            $controller->setRequest(Controller::curr()->getRequest());
+            $controller->profile();
+
+            $this->fail('The "profile" action should throw a HTTPResponse_Exception when disable_profiles is enabled');
+        } catch (HTTPResponse_Exception $e) {
+            $this->assertEquals(404, $e->getResponse()->getStatusCode(), 'The response status code should be 404 Not Found');
+        }
     }
 
     /**


### PR DESCRIPTION
This module ships with User Profiles enabled by default.

By popular opinion (as per slack chat) user profiles aren't always a desired feature, this allows for them to be disabled _easily_.

Albeit imho, profiles should be an extension/module in `suggests` instead of factory standard