### PR TITLE
FIX Ensure that draft blog posts are always viewable to users with view draft permission

### DIFF
--- a/code/model/BlogPost.php
+++ b/code/model/BlogPost.php
@@ -461,7 +461,12 @@ class BlogPost extends Page
             return false;
         }
 
-        if($this->canEdit($member)) {
+        if ($this->canEdit($member)) {
+            return true;
+        }
+
+        // If on draft stage, user has permission to view draft, so show it
+        if (Versioned::current_stage() === 'Stage') {
             return true;
         }
 
@@ -469,7 +474,7 @@ class BlogPost extends Page
          * @var SS_Datetime $publishDate
          */
         $publishDate = $this->dbObject('PublishDate');
-        if(!$publishDate->exists()) {
+        if (!$publishDate->exists()) {
             return false;
         }
 

--- a/tests/BlogPostTest.php
+++ b/tests/BlogPostTest.php
@@ -27,44 +27,67 @@ class BlogPostTest extends SapphireTest
     /**
      * @dataProvider canViewProvider
      */
-    public function testCanView($date, $user, $page, $canView)
+    public function testCanView($date, $user, $page, $canView, $stage)
     {
         $userRecord = $this->objFromFixture('Member', $user);
         $pageRecord = $this->objFromFixture('BlogPost', $page);
+        if ($stage === 'Live') {
+            $pageRecord->doPublish();
+        }
+
+        Versioned::reading_stage($stage);
         SS_Datetime::set_mock_now($date);
+
         $this->assertEquals($canView, $pageRecord->canView($userRecord));
     }
 
+    /**
+     * @return array Format:
+     *  - mock now date
+     *  - user role (see fixture)
+     *  - blog post fixture ID
+     *  - expected result
+     *  - versioned stage
+     */
     public function canViewProvider()
     {
         $someFutureDate = '2013-10-10 20:00:00';
         $somePastDate = '2009-10-10 20:00:00';
         return array(
             // Check this post given the date has passed
-            array($someFutureDate, 'Editor', 'PostA', true),
-            array($someFutureDate, 'Contributor', 'PostA', true),
-            array($someFutureDate, 'BlogEditor', 'PostA', true),
-            array($someFutureDate, 'Writer', 'PostA', true),
+            array($someFutureDate, 'Editor', 'PostA', true, 'Stage'),
+            array($someFutureDate, 'Contributor', 'PostA', true, 'Stage'),
+            array($someFutureDate, 'BlogEditor', 'PostA', true, 'Stage'),
+            array($someFutureDate, 'Writer', 'PostA', true, 'Stage'),
 
             // Check unpublished pages
-            array($somePastDate, 'Editor', 'PostA', true),
-            array($somePastDate, 'Contributor', 'PostA', true),
-            array($somePastDate, 'BlogEditor', 'PostA', true),
-            array($somePastDate, 'Writer', 'PostA', true),
+            array($somePastDate, 'Editor', 'PostA', true, 'Stage'),
+            array($somePastDate, 'Contributor', 'PostA', true, 'Stage'),
+            array($somePastDate, 'BlogEditor', 'PostA', true, 'Stage'),
+            array($somePastDate, 'Writer', 'PostA', true, 'Stage'),
 
             // Test a page that was authored by another user
 
             // Check this post given the date has passed
-            array($someFutureDate, 'Editor', 'FirstBlogPost', true),
-            array($someFutureDate, 'Contributor', 'FirstBlogPost', true),
-            array($someFutureDate, 'BlogEditor', 'FirstBlogPost', true),
-            array($someFutureDate, 'Writer', 'FirstBlogPost', true),
+            array($someFutureDate, 'Editor', 'FirstBlogPost', true, 'Stage'),
+            array($someFutureDate, 'Contributor', 'FirstBlogPost', true, 'Stage'),
+            array($someFutureDate, 'BlogEditor', 'FirstBlogPost', true, 'Stage'),
+            array($someFutureDate, 'Writer', 'FirstBlogPost', true, 'Stage'),
 
-            // Check future pages - non-editors shouldn't be able to see this
-            array($somePastDate, 'Editor', 'FirstBlogPost', true),
-            array($somePastDate, 'Contributor', 'FirstBlogPost', false),
-            array($somePastDate, 'BlogEditor', 'FirstBlogPost', false),
-            array($somePastDate, 'Writer', 'FirstBlogPost', false),
+            // Check future pages in draft stage - users with "view draft pages" permission should
+            // be able to see this, but visitors should not
+            array($somePastDate, 'Editor', 'FirstBlogPost', true, 'Stage'),
+            array($somePastDate, 'Contributor', 'FirstBlogPost', true, 'Stage'),
+            array($somePastDate, 'BlogEditor', 'FirstBlogPost', true, 'Stage'),
+            array($somePastDate, 'Writer', 'FirstBlogPost', true, 'Stage'),
+            array($somePastDate, 'Visitor', 'FirstBlogPost', false, 'Stage'),
+
+            // No future pages in live stage should be visible, even to users that can edit them (in draft)
+            array($somePastDate, 'Editor', 'FirstBlogPost', false, 'Live'),
+            array($somePastDate, 'Contributor', 'FirstBlogPost', false, 'Live'),
+            array($somePastDate, 'BlogEditor', 'FirstBlogPost', false, 'Live'),
+            array($somePastDate, 'Writer', 'FirstBlogPost', false, 'Live'),
+            array($somePastDate, 'Visitor', 'FirstBlogPost', false, 'Live'),
         );
     }
 


### PR DESCRIPTION
This change allows logged in users of any type with "view draft content" permission to view draft blog posts that are to be published in the future, where previously they would be denied without edit access.

Fixes https://github.com/silverstripe/silverstripe-sharedraftcontent/issues/70