### PR TITLE
bugfix - set $table_name for widgets

### DIFF
--- a/src/Widgets/BlogArchiveWidget.php
+++ b/src/Widgets/BlogArchiveWidget.php
@@ -65,6 +65,11 @@ class BlogArchiveWidget extends Widget
     ];
 
     /**
+     * @var string
+     */
+    private static $table_name = 'BlogArchiveWidget';
+
+    /**
      * {@inheritdoc}
      */
     public function getCMSFields()

--- a/src/Widgets/BlogCategoriesWidget.php
+++ b/src/Widgets/BlogCategoriesWidget.php
@@ -51,6 +51,11 @@ class BlogCategoriesWidget extends Widget
     ];
 
     /**
+     * @var string
+     */
+    private static $table_name = 'BlogCategoriesWidget';
+
+    /**
      * {@inheritdoc}
      */
     public function getCMSFields()

--- a/src/Widgets/BlogRecentPostsWidget.php
+++ b/src/Widgets/BlogRecentPostsWidget.php
@@ -48,6 +48,11 @@ class BlogRecentPostsWidget extends Widget
     ];
 
     /**
+     * @var string
+     */
+    private static $table_name = 'BlogRecentPostsWidget';
+
+    /**
      * {@inheritdoc}
      */
     public function getCMSFields()

--- a/src/Widgets/BlogTagsCloudWidget.php
+++ b/src/Widgets/BlogTagsCloudWidget.php
@@ -47,6 +47,11 @@ class BlogTagsCloudWidget extends Widget
     ];
 
     /**
+     * @var string
+     */
+    private static $table_name = 'BlogTagsCloudWidget';
+
+    /**
      * {@inheritdoc}
      */
     public function getCMSFields()

--- a/src/Widgets/BlogTagsWidget.php
+++ b/src/Widgets/BlogTagsWidget.php
@@ -50,6 +50,11 @@ class BlogTagsWidget extends Widget
     ];
 
     /**
+     * @var string
+     */
+    private static $table_name = 'BlogTagsWidget';
+
+    /**
      * {@inheritdoc}
      */
     public function getCMSFields()


### PR DESCRIPTION
SilverStripe 4.0.1 throws warnings when the widget module is installed.