### PR TITLE
Fixing non int pagination variable server error SS4

### DIFF
--- a/src/Model/BlogController.php
+++ b/src/Model/BlogController.php
@@ -443,7 +443,7 @@ class BlogController extends PageController
         $posts->setPageLength($pageSize);
 
         // Set current page
-        $start = $this->request->getVar($posts->getPaginationGetVar());
+        $start = (int)$this->request->getVar($posts->getPaginationGetVar());
         $posts->setPageStart($start);
 
         return $posts;


### PR DESCRIPTION
If a user tries to paginate the blog using a value that is not an integer SilverStripe will throw a server error.

Example. Visiting `blog/?start=10.1` will cause the following server error:

```You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '10.1' at line 8```

This change casts the pagination variable to an int before using it.

Note, this fix is for the master branch of the blog for SilverStripe 4.