### PR TITLE
FIX Remove "Add new blog post" button from Blog Posts GridField in a members profile

### DIFF
--- a/src/Model/BlogMemberExtension.php
+++ b/src/Model/BlogMemberExtension.php
@@ -6,6 +6,7 @@ use SilverStripe\Assets\Image;
 use SilverStripe\Blog\Forms\GridField\GridFieldConfigBlogPost;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 use SilverStripe\Forms\Tab;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\Security\Member;
@@ -120,8 +121,11 @@ class BlogMemberExtension extends DataExtension
             'BlogPosts',
             _t(__CLASS__ . '.BLOGPOSTS', 'Blog Posts'),
             $this->owner->BlogPosts(),
-            GridFieldConfigBlogPost::create()
+            $gridFieldConfig = GridFieldConfigBlogPost::create()
         );
+
+        // Remove the "add new blog post" action from a member's profile
+        $gridFieldConfig->removeComponentsByType(GridFieldAddNewButton::class);
 
         $tab->Fields()->add($gridField);
 


### PR DESCRIPTION
Resolves #519 

It doesn't make sense to allow a user to add a blog post from this CMS context, especially because:

* it throws an exception because ChildPages() is called on null
* it doesn't ask you which blog to add the blog post into

Simple fix it to remove the button from `Member::getCMSFields()`, which removes it from a user's profile section.