### PR TITLE
BlogTag existing check on URLSegment

### DIFF
--- a/code/model/BlogTag.php
+++ b/code/model/BlogTag.php
@@ -88,7 +88,7 @@ class BlogTag extends DataObject implements CategorisationObject
             // Check for duplicate tags
             $blog = $this->Blog();
             if($blog && $blog->exists()) {
-                $existing = $blog->Tags()->filter('Title', $this->Title);
+                $existing = $blog->Tags()->filter('URLSegment', $this->URLSegment);
                 if($this->ID) {
                     $existing = $existing->exclude('ID', $this->ID);
                 }


### PR DESCRIPTION
perform existing check for BlogTag on URLSegment rather than Title. 
Title is non unique in the Database, thus allows (ci) duplicates in legacy entries