### PR TITLE
Fix blog archive widget bug

### DIFF
--- a/code/widgets/BlogArchiveWidget.php
+++ b/code/widgets/BlogArchiveWidget.php
@@ -101,7 +101,7 @@ class BlogArchiveWidget extends Widget
             ->addGroupBy($publishDate)
             ->addOrderBy('"PublishDate" DESC')
             ->addLeftJoin('SiteTree' . $suffix, '"SiteTree' . $suffix . '"."ID" = "BlogPost' . $suffix . '"."ID"')
-            ->addWhere(array('"PublishDate" <= ?' => SS_Datetime::now()->Format('Y-m-d H:i:s'), 'SiteTree' . $suffix . '.ParentID' => $this->BlogID));
+            ->addWhere(array('"PublishDate" <= ?' => SS_Datetime::now()->Format('Y-m-d H:i:s'), '"SiteTree' . $suffix . '"."ParentID"' => $this->BlogID));
 
         $posts = $query->execute();
         $result = new ArrayList();

--- a/code/widgets/BlogArchiveWidget.php
+++ b/code/widgets/BlogArchiveWidget.php
@@ -100,7 +100,8 @@ class BlogArchiveWidget extends Widget
         $query = SQLSelect::create($fields, '"BlogPost' . $suffix . '"')
             ->addGroupBy($publishDate)
             ->addOrderBy('"PublishDate" DESC')
-            ->addWhere(array('"PublishDate" <= ?' => SS_Datetime::now()->Format('Y-m-d H:i:s')));
+            ->addLeftJoin('SiteTree' . $suffix, '"SiteTree' . $suffix . '"."ID" = "BlogPost' . $suffix . '"."ID"')
+            ->addWhere(array('"PublishDate" <= ?' => SS_Datetime::now()->Format('Y-m-d H:i:s'), 'SiteTree' . $suffix . '.ParentID' => $this->BlogID));
 
         $posts = $query->execute();
         $result = new ArrayList();

--- a/tests/Widgets/BlogArchiveWidgetTest.php
+++ b/tests/Widgets/BlogArchiveWidgetTest.php
@@ -26,16 +26,26 @@ class BlogArchiveWidgetTest extends SapphireTest
 
     public function testArchiveMonthlyFromStage()
     {
-        $widget = $this->objFromFixture('BlogArchiveWidget', 'archive-monthly');
-        $archive = $widget->getArchive();
+        $widgetA = $this->objFromFixture('BlogArchiveWidget', 'archive-monthly-a');
+        $archiveA = $widgetA->getArchive();
 
-        $this->assertInstanceOf('SS_List', $archive);
-        $this->assertCount(3, $archive);
+        $this->assertInstanceOf('SS_List', $archiveA);
+        $this->assertCount(3, $archiveA);
         $this->assertDOSContains(array(
             array('Title' => 'August 2017'),
             array('Title' => 'September 2017'),
             array('Title' => 'May 2015'),
-        ), $archive);
+        ), $archiveA);
+
+        $widgetB = $this->objFromFixture('BlogArchiveWidget', 'archive-monthly-b');
+        $archiveB = $widgetB->getArchive();
+
+        $this->assertInstanceOf('SS_List', $archiveB);
+        $this->assertCount(2, $archiveB);
+        $this->assertDOSContains(array(
+            array('Title' => 'March 2016'),
+            array('Title' => 'June 2016'),
+        ), $archiveB);
     }
 
     public function testArchiveMonthlyFromLive()
@@ -45,7 +55,7 @@ class BlogArchiveWidgetTest extends SapphireTest
         $this->objFromFixture('BlogPost', 'post-b')->doPublish();
         Versioned::reading_stage('Live');
 
-        $widget = $this->objFromFixture('BlogArchiveWidget', 'archive-monthly');
+        $widget = $this->objFromFixture('BlogArchiveWidget', 'archive-monthly-a');
         $archive = $widget->getArchive();
 
         $this->assertCount(1, $archive);
@@ -60,15 +70,24 @@ class BlogArchiveWidgetTest extends SapphireTest
 
     public function testArchiveYearly()
     {
-        $widget = $this->objFromFixture('BlogArchiveWidget', 'archive-yearly');
-        $archive = $widget->getArchive();
+        $widgetA = $this->objFromFixture('BlogArchiveWidget', 'archive-yearly-a');
+        $archiveA = $widgetA->getArchive();
 
-        $this->assertInstanceOf('SS_List', $archive);
-        $this->assertCount(2, $archive);
+        $this->assertInstanceOf('SS_List', $archiveA);
+        $this->assertCount(2, $archiveA);
         $this->assertDOSContains(array(
             array('Title' => '2017'),
             array('Title' => '2015'),
-        ), $archive);
+        ), $archiveA);
+
+        $widgetB = $this->objFromFixture('BlogArchiveWidget', 'archive-yearly-b');
+        $archiveB = $widgetB->getArchive();
+
+        $this->assertInstanceOf('SS_List', $archiveB);
+        $this->assertCount(1, $archiveB);
+        $this->assertDOSContains(array(
+            array('Title' => '2016'),
+        ), $archiveB);
     }
 
     public function testArchiveMonthlyWithNewPostsAdded()
@@ -76,7 +95,7 @@ class BlogArchiveWidgetTest extends SapphireTest
         $original = Versioned::current_stage();
         Versioned::reading_stage('Stage');
 
-        $widget = $this->objFromFixture('BlogArchiveWidget', 'archive-monthly');
+        $widget = $this->objFromFixture('BlogArchiveWidget', 'archive-monthly-a');
         $archive = $widget->getArchive();
 
         $this->assertCount(3, $archive, 'Three months are shown in the blog archive list from fixtures');
@@ -84,7 +103,7 @@ class BlogArchiveWidgetTest extends SapphireTest
         SS_Datetime::set_mock_now('2018-01-01 12:00:00');
 
         $newPost = new BlogPost;
-        $newPost->ParentID = $this->objFromFixture('Blog', 'my-blog')->ID;
+        $newPost->ParentID = $this->objFromFixture('Blog', 'blog-a')->ID;
         $newPost->Title = 'My new blog post';
         $newPost->PublishDate = '2018-01-01 08:00:00'; // Same day as the mocked now, but slightly earlier
         $newPost->write();

--- a/tests/Widgets/BlogArchiveWidgetTest.yml
+++ b/tests/Widgets/BlogArchiveWidgetTest.yml
@@ -1,27 +1,45 @@
 Blog:
-  my-blog:
-    Title: My Blog
+  blog-a:
+    Title: Blog A
+  blog-b:
+    Title: Blog B
 
 BlogPost:
   post-a:
     Title: September Digest
     PublishDate: 2017-09-01 00:00:00
-    ParentID: =>Blog.my-blog
+    ParentID: =>Blog.blog-a
   post-b:
     Title: August is Awesome
     PublishDate: 2017-08-01 00:00:00
-    ParentID: =>Blog.my-blog
+    ParentID: =>Blog.blog-a
   post-c:
     Title: 2015 is so two years ago
     PublishDate: 2015-05-02 00:01:02
-    ParentID: =>Blog.my-blog
+    ParentID: =>Blog.blog-a
+  post-d:
+    Title: Blog post on Blog B
+    PublishDate: 2016-03-13 21:05:36
+    ParentID: =>Blog.blog-b
+  post-e:
+    Title: Blog post 2 on Blog B
+    PublishDate: 2016-06-15 10:00:00
+    ParentID: =>Blog.blog-b
 
 BlogArchiveWidget:
-  archive-monthly:
+  archive-monthly-a:
     NumberToDisplay: 5
     ArchiveType: Monthly
-    BlogID: =>Blog.my-blog
-  archive-yearly:
+    BlogID: =>Blog.blog-a
+  archive-monthly-b:
+    NumberToDisplay: 5
+    ArchiveType: Monthly
+    BlogID: =>Blog.blog-b
+  archive-yearly-a:
     NumberToDisplay: 5
     ArchiveType: Yearly
-    BlogID: =>Blog.my-blog
+    BlogID: =>Blog.blog-a
+  archive-yearly-b:
+    NumberToDisplay: 5
+    ArchiveType: Yearly
+    BlogID: =>Blog.blog-b


### PR DESCRIPTION
Fixes blog archive widget bug to only get the archive months for the blog linked to in this widget.

What was happening before is if you had more than one blog, the blog archive widget would get every blog post from every blog, create the archive month or year list from those blog posts and display that date list. This would result in some archive months (or years) that did not apply to the relevant blog. Clicking on those links would display an empty list.

This pull request filters the blog posts used for the archive loop by the widget blog ID.