### PR TITLE
Add db index on PublishDate

### DIFF
--- a/code/model/BlogPost.php
+++ b/code/model/BlogPost.php
@@ -32,6 +32,13 @@ class BlogPost extends Page
         'AuthorNames' => 'Varchar(1024)',
         'Summary' => 'HTMLText',
     );
+    
+    /**
+     * @var array
+     */
+    private static $indexes = array(
+        'PublishDate' => true,
+    ):
 
     /**
      * @var array

--- a/code/model/BlogPost.php
+++ b/code/model/BlogPost.php
@@ -38,7 +38,7 @@ class BlogPost extends Page
      */
     private static $indexes = array(
         'PublishDate' => true,
-    ):
+    );
 
     /**
      * @var array


### PR DESCRIPTION
It's is quite common to order by the publish date or do where operations on this column. In many cases, this causes full table scans and other DB CPU intensive work.

In my opinion this should be a default for this module.