### PR TITLE
FIX: Update Blog archive date formats for SS4

### DIFF
--- a/src/Model/BlogController.php
+++ b/src/Model/BlogController.php
@@ -396,9 +396,9 @@ class BlogController extends PageController
             if ($this->owner->getArchiveDay()) {
                 $date = $this->owner->getArchiveDate()->Nice();
             } elseif ($this->owner->getArchiveMonth()) {
-                $date = $this->owner->getArchiveDate()->format('F, Y');
+                $date = $this->owner->getArchiveDate()->format('MMMM, y');
             } else {
-                $date = $this->owner->getArchiveDate()->format('Y');
+                $date = $this->owner->getArchiveDate()->format('y');
             }
 
             $items[] = _t(

--- a/templates/SilverStripe/Blog/Model/Layout/Blog.ss
+++ b/templates/SilverStripe/Blog/Model/Layout/Blog.ss
@@ -9,9 +9,9 @@
 				<% if $ArchiveDay %>
 					$ArchiveDate.Nice
 				<% else_if $ArchiveMonth %>
-					$ArchiveDate.format('F, Y')
+					$ArchiveDate.format('MMMM, y')
 				<% else %>
-					$ArchiveDate.format('Y')
+					$ArchiveDate.format('y')
 				<% end_if %>
 			<% else_if $CurrentTag %>
 				<%t SilverStripe\\Blog\\Model\\Blog.Tag 'Tag' %>: $CurrentTag.Title


### PR DESCRIPTION
The date formats for the blog archives were incompatible with the changes made in SS4. These changes should be required for all similar versions.