### PR TITLE
FIX: Add Blog::getControllerName() so /category links work

### DIFF
--- a/src/Model/Blog.php
+++ b/src/Model/Blog.php
@@ -700,4 +700,9 @@ class Blog extends Page implements PermissionProvider
 
         return $group;
     }
+
+    public function getControllerName()
+    {
+        return BlogController::class;
+    }
 }


### PR DESCRIPTION
The `Blog` model doesn't include the required `getControllerName()` method, so it defaults to using `PageController`, meaning that links to blog categories (e.g. www.example.com/blog/category/example-category) doesn't work. Also broken include links to profiles, tags etc. - basically any functionality on BlogController doesn't work.