### PR TITLE
FIX Multibyte URL encoding for blog profiles, and encoded params in functional tests

### DIFF
--- a/src/Model/BlogController.php
+++ b/src/Model/BlogController.php
@@ -106,12 +106,16 @@ class BlogController extends PageController
     public function getCurrentProfile()
     {
         $urlSegment = $this->request->param('URLSegment');
-
         if ($urlSegment) {
             $filter = URLSegmentFilter::create();
+            // url encode unless it's multibyte (already pre-encoded in the database)
+            // see https://github.com/silverstripe/silverstripe-cms/pull/2384
+            if (!$filter->getAllowMultibyte()) {
+                $urlSegment = rawurlencode($urlSegment);
+            }
 
             return Member::get()
-                ->filter('URLSegment', $filter->filter($urlSegment))
+                ->filter('URLSegment', $urlSegment)
                 ->first();
         }
 

--- a/tests/BlogFunctionalTest.php
+++ b/tests/BlogFunctionalTest.php
@@ -23,14 +23,14 @@ class BlogFunctionalTest extends FunctionalTest
 
     public function testBlogWithMultibyteUrl()
     {
-        $result = $this->get('آبید');
+        $result = $this->get(rawurlencode('آبید'));
 
         $this->assertEquals(200, $result->getStatusCode());
     }
 
     public function testMemberProfileWithMultibyteUrlAndName()
     {
-        $result = $this->get('آبید/profile/عبّاس-آبان');
+        $result = $this->get(rawurlencode('آبید') . '/profile/' . rawurlencode('عبّاس-آبان'));
 
         $this->assertEquals(200, $result->getStatusCode());
         $this->assertContains('My Blog Post', $result->getBody());
@@ -38,7 +38,7 @@ class BlogFunctionalTest extends FunctionalTest
 
     public function testMemberProfileWithMultibyteUrlAndEnglishName()
     {
-        $result = $this->get('آبید/profile/bob-jones');
+        $result = $this->get(rawurlencode('آبید') . '/profile/bob-jones');
 
         $this->assertEquals(200, $result->getStatusCode());
         $this->assertContains('My Blog Post', $result->getBody());


### PR DESCRIPTION
* Functional tests should encode multibyte URL params before passing them to `get()`, to replicate real world scenarios
* Blog profile controller action does not need to double encode the argument

Fixes https://github.com/silverstripe/silverstripe-blog/issues/488

Requires https://github.com/silverstripe/silverstripe-cms/pull/2384 to be merged and merged up for tests to pass across all versions.