### PR TITLE
FIX Categories and tags now respect multibyte url configuration

### DIFF
--- a/src/Model/Blog.php
+++ b/src/Model/Blog.php
@@ -17,6 +17,8 @@ use SilverStripe\Forms\NumericField;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
+use SilverStripe\ORM\HasManyList;
+use SilverStripe\ORM\ManyManyList;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\UnsavedRelationList;
 use SilverStripe\Security\Group;

--- a/src/Model/BlogController.php
+++ b/src/Model/BlogController.php
@@ -267,9 +267,14 @@ class BlogController extends PageController
         $tag = $this->request->param('Tag');
         if ($tag) {
             $filter = URLSegmentFilter::create();
+            // url encode unless it's multibyte (already pre-encoded in the database)
+            // see https://github.com/silverstripe/silverstripe-cms/pull/2384
+            if (!$filter->getAllowMultibyte()) {
+                $tag = rawurlencode($tag);
+            }
 
             return $dataRecord->Tags()
-                ->filter('URLSegment', [$tag, $filter->filter($tag)])
+                ->filter('URLSegment', $tag)
                 ->first();
         }
         return null;
@@ -289,9 +294,8 @@ class BlogController extends PageController
 
             if ($this->isRSS()) {
                 return $this->rssFeed($this->blogPosts, $category->getLink());
-            } else {
-                return $this->render();
             }
+            return $this->render();
         }
 
         $this->httpError(404, 'Not Found');
@@ -313,9 +317,14 @@ class BlogController extends PageController
         $category = $this->request->param('Category');
         if ($category) {
             $filter = URLSegmentFilter::create();
+            // url encode unless it's multibyte (already pre-encoded in the database)
+            // see https://github.com/silverstripe/silverstripe-cms/pull/2384
+            if (!$filter->getAllowMultibyte()) {
+                $category = rawurlencode($category);
+            }
 
             return $dataRecord->Categories()
-                ->filter('URLSegment', [$category, $filter->filter($category)])
+                ->filter('URLSegment', $category)
                 ->first();
         }
         return null;

--- a/src/Model/BlogPost.php
+++ b/src/Model/BlogPost.php
@@ -16,6 +16,7 @@ use SilverStripe\Forms\ToggleCompositeField;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\FieldType\DBHTMLText;
+use SilverStripe\ORM\ManyManyList;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\UnsavedRelationList;
 use SilverStripe\Security\Group;
@@ -25,7 +26,6 @@ use SilverStripe\Security\Security;
 use SilverStripe\TagField\TagField;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\ArrayData;
-use SilverStripe\View\Parsers\ShortcodeParser;
 use SilverStripe\View\Requirements;
 
 /**

--- a/tests/Model/BlogControllerFunctionalTest.php
+++ b/tests/Model/BlogControllerFunctionalTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SilverStripe\Blog\Tests\Model;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\i18n\i18n;
+use SilverStripe\View\Parsers\URLSegmentFilter;
+
+class BlogControllerFunctionalTest extends FunctionalTest
+{
+    protected static $fixture_file = 'BlogControllerFunctionalTest.yml';
+
+    protected static $use_draft_site = true;
+
+    protected function setUp()
+    {
+        Config::modify()->set(URLSegmentFilter::class, 'default_allow_multibyte', true);
+        i18n::set_locale('fa_IR');
+
+        parent::setUp();
+    }
+
+    public function testGetCategoriesWithMultibyteUrl()
+    {
+        $result = $this->get('my-blog/category/' . rawurlencode('آبید'));
+
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertContains('آبید', $result->getBody());
+    }
+
+    public function testGetTagsWithMultibyteUrl()
+    {
+        $result = $this->get('my-blog/tag/' . rawurlencode('برتراند'));
+
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertContains('برتراند', $result->getBody());
+    }
+}

--- a/tests/Model/BlogControllerFunctionalTest.yml
+++ b/tests/Model/BlogControllerFunctionalTest.yml
@@ -1,0 +1,29 @@
+SilverStripe\Blog\Model\BlogCategory:
+  category_a:
+    Title: آبید
+    URLSegment: آبید
+
+SilverStripe\Blog\Model\BlogTag:
+  tag_a:
+    Title: برتراند
+    URLSegment: برتراند
+
+SilverStripe\Blog\Model\Blog:
+  blog_a:
+    URLSegment: my-blog
+    Title: My Blog
+    Categories:
+      - =>SilverStripe\Blog\Model\BlogCategory.category_a
+    Tags:
+      - =>SilverStripe\Blog\Model\BlogTag.tag_a
+
+SilverStripe\Blog\Model\BlogPost:
+  blogpost_a:
+    Title: My Blog Post
+    URLSegment: آبیدآبید
+    PublishDate: 2017-08-01 00:00:00
+    Parent: =>SilverStripe\Blog\Model\Blog.blog_a
+    Categories:
+      - =>SilverStripe\Blog\Model\BlogCategory.category_a
+    Tags:
+      - =>SilverStripe\Blog\Model\BlogTag.tag_a


### PR DESCRIPTION
Previously multibyte URLs would always work, regardless of URLSegmentFilter::$default_allow_multibyte. This change means that they will only work when the setting is enabled.

Follow up from https://github.com/silverstripe/silverstripe-blog/pull/571