### PR TITLE
MINOR: avoid current blog post being included in the recent posts widget

### DIFF
--- a/src/Widgets/BlogRecentPostsWidget.php
+++ b/src/Widgets/BlogRecentPostsWidget.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Blog\Widgets;
 
 use SilverStripe\Blog\Model\Blog;
+use SilverStripe\Control\Director;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\NumericField;
@@ -81,6 +82,7 @@ class BlogRecentPostsWidget extends Widget
 
         if ($blog) {
             return $blog->getBlogPosts()
+                ->filter('ID:not', Director::get_current_page()->ID)
                 ->sort('"PublishDate" DESC')
                 ->limit($this->NumberOfPosts);
         }


### PR DESCRIPTION
Hello @robbieaverill and @NightJar 

I've noticed the current blog post is included in the widget for the recent blog posts (if it is falling in the criteria for the most recent posts). I can't see a use case for linking back to the article you are currently viewing. The PR would fix this by excluding the current post from the list.

Cheers,
Peter