### PR TITLE
BlogArchiveWidget limit fix

### DIFF
--- a/src/Widgets/BlogArchiveWidget.php
+++ b/src/Widgets/BlogArchiveWidget.php
@@ -150,6 +150,6 @@ class BlogArchiveWidget extends Widget
 
         $this->extend('updateGetArchive', $result);
 
-        return $this->NumberToDisplay ? $result->limit($this->NumberToDisplay) : $result;
+        return $result->limit($this->NumberToDisplay);
     }
 }

--- a/src/Widgets/BlogArchiveWidget.php
+++ b/src/Widgets/BlogArchiveWidget.php
@@ -150,6 +150,6 @@ class BlogArchiveWidget extends Widget
 
         $this->extend('updateGetArchive', $result);
 
-        return $result;
+        return $this->NumberToDisplay ? $result->limit($this->NumberToDisplay) : $result;
     }
 }


### PR DESCRIPTION
Add limit to the return $result. If NumberToDisplay is unset it doesn't limit it.

@robbieaverill you asked if I could apply the temp fix at the template level, but i figured if i could make a PR then i may as well just put it in where it ought to go.