### PR TITLE
UX expand custom summary if field has value

### DIFF
--- a/src/Model/BlogPost.php
+++ b/src/Model/BlogPost.php
@@ -258,6 +258,10 @@ class BlogPost extends Page
             $summaryHolder->setHeadingLevel(4);
             $summaryHolder->addExtraClass('custom-summary');
 
+            if ($this->Summary) {
+                $summaryHolder->setStartClosed(false);
+            }
+
             $fields->insertAfter('FeaturedImage', $summaryHolder);
 
             $authorField = ListboxField::create(


### PR DESCRIPTION
resolves #566

This only expands the toggle field if there is a value present. There was discussion of having it expanded all the time which would be simple enough to update.