### PR TITLE
Make featured images directory configurable

### DIFF
--- a/docs/en/configuring-featured-images.md
+++ b/docs/en/configuring-featured-images.md
@@ -1,0 +1,13 @@
+## Configuring featured images
+
+By default, featured images for the blog are uploaded to the default SilverStripe location.  
+If you prefer, you can specify a directory into which featured images will be uploaded by adding the following to your project's config:
+
+
+
+```yaml
+SilverStripe\Blog\Model\BlogPost:
+  featured_images_directory: 'blog-images'
+```
+
+replacing 'blog-images' with the name of the directory you wish to use.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -5,6 +5,7 @@
  * [Configuring blog when on large websites](configuring-large-websites.md)
  * [Configuring widgets](configuring-widgets.md)
  * [Configuring pagination](configuring-pagination.md)
+ * [Configuring featured image uploads](configuring-featured-images.md)
 
 ## CMS user help
  * [User guide](userguide/index.md)

--- a/src/Model/BlogPost.php
+++ b/src/Model/BlogPost.php
@@ -171,6 +171,14 @@ class BlogPost extends Page
     private static $minutes_to_read_wpm = 200;
 
     /**
+     * Sets the upload directory for featured images to help keep your files organised
+     *
+     * @config
+     * @var string
+     */
+    private static $featured_images_directory = null;
+
+    /**
      * Determine the role of the given member.
      *
      * Call be called via template to determine the current user.
@@ -235,6 +243,11 @@ class BlogPost extends Page
         $this->beforeUpdateCMSFields(function ($fields) {
             $uploadField = UploadField::create('FeaturedImage', _t(__CLASS__ . '.FeaturedImage', 'Featured Image'));
             $uploadField->getValidator()->setAllowedExtensions(['jpg', 'jpeg', 'png', 'gif']);
+
+            $uploadDirectory = $this->config()->get('featured_images_directory');
+            if ($uploadDirectory != '') {
+                $uploadField->setFolderName($uploadDirectory);
+            }
 
             /**
              * @var FieldList $fields


### PR DESCRIPTION
This one comes up quite often for me, especially where a CMS user has a lot of files.    Adding the ability to  configure the uploads directory of blog images can make it a little easier to be organised and to find images for reuse.