### PR TITLE
Category / Tag Rewrite - Remove dependency on Blog

### DIFF
--- a/src/Admin/GridFieldCategorisationConfig.php
+++ b/src/Admin/GridFieldCategorisationConfig.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Blog\Admin;
 
 use SilverStripe\Blog\Forms\GridField\GridFieldAddByDBField;
 use SilverStripe\Blog\Model\CategorisationObject;
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
@@ -12,13 +13,14 @@ use SilverStripe\ORM\SS_List;
 class GridFieldCategorisationConfig extends GridFieldConfig_RecordEditor
 {
     /**
-     * @param int $itemsPerPage
+     * @param int           $itemsPerPage
      * @param array|SS_List $mergeRecords
-     * @param string $parentType
-     * @param string $parentMethod
-     * @param string $childMethod
+     * @param string        $parentType
+     * @param string        $parentMethod
+     * @param string        $childMethod
+     * @param SiteTree      $parent
      */
-    public function __construct($itemsPerPage, $mergeRecords, $parentType, $parentMethod, $childMethod)
+    public function __construct($itemsPerPage, $mergeRecords, $parentType, $parentMethod, $childMethod, $parent)
     {
         parent::__construct($itemsPerPage);
 
@@ -39,31 +41,24 @@ class GridFieldCategorisationConfig extends GridFieldConfig_RecordEditor
 
         $columns->setFieldFormatting(
             [
-                'BlogPostsCount' => function ($value, CategorisationObject $item) {
+                'BlogPostsCount'    => function ($value, CategorisationObject $item) use ($parent) {
+                    return $item
+                        ->BlogPosts()
+                        ->filter(['ParentID' => $parent->ID])
+                        ->Count();
+                },
+                'BlogPostsAllCount' => function ($value, CategorisationObject $item) {
                     return $item->BlogPosts()->Count();
-                }
+                },
             ]
         );
-
-        $this->changeColumnOrder();
-    }
-
-    /**
-     * Reorders GridField columns so that Actions is last.
-     */
-    protected function changeColumnOrder()
-    {
-        /**
-         * @var GridFieldDataColumns $columns
-         */
-        $columns = $this->getComponentByType(GridFieldDataColumns::class);
-
         $columns->setDisplayFields(
             [
-                'Title'          => _t(__CLASS__ . '.Title', 'Title'),
-                'BlogPostsCount' => _t(__CLASS__ . '.Posts', 'Posts'),
-                'MergeAction'    => 'MergeAction',
-                'Actions'        => 'Actions'
+                'Title'             => _t(__CLASS__ . '.Title', 'Title'),
+                'BlogPostsCount'    => _t(__CLASS__ . '.PostsThisBlog', 'Posts (This Blog)'),
+                'BlogPostsAllCount' => _t(__CLASS__ . '.PostsAllBlogs', 'Posts (All Blogs)'),
+                'MergeAction'       => 'MergeAction',
+                'Actions'           => 'Actions'
             ]
         );
     }

--- a/src/Admin/GridFieldCategorisationConfig.php
+++ b/src/Admin/GridFieldCategorisationConfig.php
@@ -4,7 +4,6 @@ namespace SilverStripe\Blog\Admin;
 
 use SilverStripe\Blog\Forms\GridField\GridFieldAddByDBField;
 use SilverStripe\Blog\Model\CategorisationObject;
-use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
@@ -18,9 +17,8 @@ class GridFieldCategorisationConfig extends GridFieldConfig_RecordEditor
      * @param string        $parentType
      * @param string        $parentMethod
      * @param string        $childMethod
-     * @param SiteTree      $parent
      */
-    public function __construct($itemsPerPage, $mergeRecords, $parentType, $parentMethod, $childMethod, $parent)
+    public function __construct($itemsPerPage, $mergeRecords, $parentType, $parentMethod, $childMethod)
     {
         parent::__construct($itemsPerPage);
 
@@ -41,11 +39,8 @@ class GridFieldCategorisationConfig extends GridFieldConfig_RecordEditor
 
         $columns->setFieldFormatting(
             [
-                'BlogPostsCount'    => function ($value, CategorisationObject $item) use ($parent) {
-                    return $item
-                        ->BlogPosts()
-                        ->filter(['ParentID' => $parent->ID])
-                        ->Count();
+                'BlogPostsCount'    => function ($value, CategorisationObject $item) {
+                    return $item->getBlogCount();
                 },
                 'BlogPostsAllCount' => function ($value, CategorisationObject $item) {
                     return $item->BlogPosts()->Count();

--- a/src/Forms/GridField/GridFieldAddByDBField.php
+++ b/src/Forms/GridField/GridFieldAddByDBField.php
@@ -99,6 +99,7 @@ class GridFieldAddByDBField implements GridField_ActionProvider, GridField_HTMLP
                 $obj->setCastedField($dbField, $data['gridfieldaddbydbfield'][$obj->ClassName][$dbField]);
 
                 if ($obj->canCreate()) {
+                    $obj->write();
                     $id = $gridField->getList()->add($obj);
                     if (!$id) {
                         $gridField->setCustomValidationMessage(

--- a/src/Model/Blog.php
+++ b/src/Model/Blog.php
@@ -135,17 +135,15 @@ class Blog extends Page implements PermissionProvider
      */
     public function Tags($hideEmpty = true)
     {
-        $tags = BlogTag::get();
-        if ($this->ID) {
-            $tags->setDataQueryParam('BlogID', $this->ID);
+        $tags = BlogTag::get()->setDataQueryParam('BlogID', $this->ID);
 
-            // Conditionally hide empty tags
-            if ($hideEmpty) {
-                $tags = $tags->filter([
-                    'BlogPosts.ParentID' => $this->ID,
-                ]);
-            }
+        // Conditionally hide empty tags
+        if ($this->ID && $hideEmpty) {
+            $tags = $tags->filter([
+                'BlogPosts.ParentID' => $this->ID,
+            ]);
         }
+
         $this->extend('updateBlogTags', $tags);
         return $tags;
     }
@@ -158,17 +156,15 @@ class Blog extends Page implements PermissionProvider
      */
     public function Categories($hideEmpty = true)
     {
-        $tags = BlogCategory::get();
-        if ($this->ID) {
-            $tags->setDataQueryParam('BlogID', $this->ID);
+        $tags = BlogCategory::get()->setDataQueryParam('BlogID', $this->ID);
 
-            // Conditionally hide empty categories
-            if ($hideEmpty) {
-                $tags = $tags->filter([
-                    'BlogPosts.ParentID' => $this->ID,
-                ]);
-            }
+        // Conditionally hide empty categories
+        if ($this->ID && $hideEmpty) {
+            $tags = $tags->filter([
+                'BlogPosts.ParentID' => $this->ID,
+            ]);
         }
+
         $this->extend('updateBlogCategories', $tags);
         return $tags;
     }
@@ -184,7 +180,7 @@ class Blog extends Page implements PermissionProvider
             if (!$this->canEdit()) {
                 return;
             }
-
+            
             $categories = GridField::create(
                 'Categories',
                 _t(__CLASS__ . '.Categories', 'Categories'),
@@ -194,8 +190,7 @@ class Blog extends Page implements PermissionProvider
                     $this->Categories(false)->sort('Title'),
                     BlogCategory::class,
                     'Categories',
-                    'BlogPosts',
-                    $this
+                    'BlogPosts'
                 )
             );
 
@@ -208,8 +203,7 @@ class Blog extends Page implements PermissionProvider
                     $this->Tags(false)->sort('Title'),
                     BlogTag::class,
                     'Tags',
-                    'BlogPosts',
-                    $this
+                    'BlogPosts'
                 )
             );
 

--- a/src/Model/BlogCategory.php
+++ b/src/Model/BlogCategory.php
@@ -3,16 +3,14 @@
 namespace SilverStripe\Blog\Model;
 
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ManyManyList;
 
 /**
  * A blog category for generalising blog posts.
  *
-*
- * @method Blog Blog()
- *
+ * @method ManyManyList|BlogPost[] BlogPosts()
  * @property string $Title
  * @property string $URLSegment
- * @property int $BlogID
  */
 class BlogCategory extends DataObject implements CategorisationObject
 {
@@ -44,8 +42,8 @@ class BlogCategory extends DataObject implements CategorisationObject
     /**
      * @var array
      */
-    private static $has_one = [
-        'Blog' => Blog::class,
+    private static $indexes = [
+        'URLSegment' => true,
     ];
 
     /**

--- a/src/Model/BlogCategory.php
+++ b/src/Model/BlogCategory.php
@@ -54,6 +54,11 @@ class BlogCategory extends DataObject implements CategorisationObject
     ];
 
     /**
+     * @var string
+     */
+    private static $default_sort = '"BlogCategory"."Title" ASC';
+
+    /**
      * {@inheritdoc}
      */
     protected function getListUrlSegment()

--- a/src/Model/BlogController.php
+++ b/src/Model/BlogController.php
@@ -177,7 +177,9 @@ class BlogController extends PageController
             return (int)$this->urlParams['Year'];
         }
 
-        if ($this->urlParams['Action'] === 'archive') {
+        if (empty($this->urlParams['Year']) &&
+            $this->urlParams['Action'] === 'archive'
+        ) {
             return DBDatetime::now()->Year();
         }
 
@@ -196,6 +198,10 @@ class BlogController extends PageController
         $month = isset($this->urlParams['Month'])
             ? $this->urlParams['Month']
             : null;
+
+        if (!$month) {
+            return null;
+        }
 
         if (preg_match('/^[0-9]{1,2}$/', $month)
             && $month > 0
@@ -219,6 +225,10 @@ class BlogController extends PageController
         $day = isset($this->urlParams['Day'])
             ? $this->urlParams['Day']
             : null;
+
+        if (!$day) {
+            return null;
+        }
 
         // Cannot calculate day without month and year
         $month = $this->getArchiveMonth();

--- a/src/Model/BlogMemberExtension.php
+++ b/src/Model/BlogMemberExtension.php
@@ -10,6 +10,7 @@ use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\ManyManyList;
 use SilverStripe\Security\Member;
 use SilverStripe\View\Parsers\URLSegmentFilter;
 use SilverStripe\View\Requirements;
@@ -17,6 +18,10 @@ use SilverStripe\View\Requirements;
 /**
  * This class is responsible for add Blog specific behaviour to Members.
  *
+ * @property string $URLSegment
+ * @property string $BlogProfileSummary
+ * @method Image BlogProfileImage()
+ * @method ManyManyList|BlogPost[] BlogPosts()
  */
 class BlogMemberExtension extends DataExtension
 {

--- a/src/Model/BlogObject.php
+++ b/src/Model/BlogObject.php
@@ -97,11 +97,6 @@ trait BlogObject
             return $validation;
         }
 
-        $blog = $this->Blog();
-        if (!$blog || !$blog->exists()) {
-            return $validation;
-        }
-
         if ($this->getDuplicatesByField('Title')->count() > 0) {
             $validation->addError($this->getDuplicateError(), self::DUPLICATE_EXCEPTION);
         }

--- a/src/Model/BlogObject.php
+++ b/src/Model/BlogObject.php
@@ -68,6 +68,24 @@ trait BlogObject
     }
 
     /**
+     * Number of times this object has blog posts in the current blog
+     *
+     * @return int
+     */
+    public function getBlogCount()
+    {
+        $blog = $this->Blog();
+        if (!$blog) {
+            return 0;
+        }
+
+        return $this
+            ->BlogPosts()
+            ->filter(['ParentID' => $blog->ID])
+            ->Count();
+    }
+
+    /**
      * {@inheritdoc}
      * @return ValidationResult
      */

--- a/src/Model/BlogObject.php
+++ b/src/Model/BlogObject.php
@@ -39,7 +39,7 @@ trait BlogObject
      */
     public function Blog()
     {
-        $blogID = $this->getSourceQueryParam('BlogID');
+        $blogID = $this->getBlogID();
         if ($blogID) {
             /** @var Blog $blog */
             $blog = Blog::get()->byID($blogID);
@@ -193,6 +193,26 @@ trait BlogObject
 
         $blog = $this->Blog();
         return $blog && $blog->canEdit($member);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBlogID()
+    {
+        return $this->getSourceQueryParam('BlogID');
+    }
+
+    /**
+     * Set a blog ID for this record
+     *
+     * @param int $id
+     * @return $this
+     */
+    public function setBlogID($id)
+    {
+        $this->setSourceQueryParam('BlogID', $id);
+        return $this;
     }
 
     protected function onBeforeWrite()

--- a/src/Model/BlogObject.php
+++ b/src/Model/BlogObject.php
@@ -124,7 +124,8 @@ trait BlogObject
             return $extended;
         }
 
-        return $this->Blog()->canView($member);
+        $blog = $this->Blog();
+        return $blog && $blog->canView($member);
     }
 
     /**
@@ -158,7 +159,8 @@ trait BlogObject
             return $extended;
         }
 
-        return $this->Blog()->canDelete($member);
+        $blog = $this->Blog();
+        return $blog && $blog->canDelete($member);
     }
 
     /**
@@ -176,7 +178,8 @@ trait BlogObject
             return $extended;
         }
 
-        return $this->Blog()->canEdit($member);
+        $blog = $this->Blog();
+        return $blog && $blog->canEdit($member);
     }
 
     protected function onBeforeWrite()

--- a/src/Model/BlogPost.php
+++ b/src/Model/BlogPost.php
@@ -313,14 +313,6 @@ class BlogPost extends Page
             }
 
             // Get categories and tags
-            $parent = $this->Parent();
-            $categories = $parent instanceof Blog
-                ? $parent->Categories()
-                : BlogCategory::get();
-            $tags = $parent instanceof Blog
-                ? $parent->Tags()
-                : BlogTag::get();
-
             // @todo: Reimplement the sidebar
             // $options = BlogAdminSidebar::create(
             $fields->addFieldsToTab(
@@ -330,7 +322,7 @@ class BlogPost extends Page
                     TagField::create(
                         'Categories',
                         _t(__CLASS__ . '.Categories', 'Categories'),
-                        $categories,
+                        BlogCategory::get(),
                         $this->Categories()
                     )
                         ->setCanCreate($this->canCreateCategories())
@@ -338,7 +330,7 @@ class BlogPost extends Page
                     TagField::create(
                         'Tags',
                         _t(__CLASS__ . '.Tags', 'Tags'),
-                        $tags,
+                        BlogTag::get(),
                         $this->Tags()
                     )
                         ->setCanCreate($this->canCreateTags())
@@ -815,5 +807,17 @@ class BlogPost extends Page
         if (!$this->exists() && ($member = Security::getCurrentUser())) {
             $this->Authors()->add($member);
         }
+    }
+
+    /**
+     * So that tags / categories queried through this post generate the correct Link()
+     *
+     * @return array
+     */
+    public function getInheritableQueryParams()
+    {
+        $params = parent::getInheritableQueryParams();
+        $params['BlogID'] = $this->ParentID;
+        return $params;
     }
 }

--- a/src/Model/BlogPost.php
+++ b/src/Model/BlogPost.php
@@ -492,32 +492,6 @@ class BlogPost extends Page
 
     /**
      * {@inheritdoc}
-     *
-     * Sets blog relationship on all categories and tags assigned to this post.
-     */
-    public function onAfterWrite()
-    {
-        parent::onAfterWrite();
-
-        foreach ($this->Categories() as $category) {
-            /**
-             * @var BlogCategory $category
-             */
-            $category->BlogID = $this->ParentID;
-            $category->write();
-        }
-
-        foreach ($this->Tags() as $tag) {
-            /**
-             * @var BlogTag $tag
-             */
-            $tag->BlogID = $this->ParentID;
-            $tag->write();
-        }
-    }
-
-    /**
-     * {@inheritdoc}
      */
     public function canView($member = null)
     {

--- a/src/Model/BlogTag.php
+++ b/src/Model/BlogTag.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Blog\Model;
 
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ManyManyList;
 
 /**
  * A blog tag for keyword descriptions of a blog post.
@@ -10,9 +11,9 @@ use SilverStripe\ORM\DataObject;
  *
  * @method Blog Blog()
  *
+ * @method ManyManyList|BlogPost[] BlogPosts()
  * @property string $Title
  * @property string $URLSegment
- * @property int $BlogID
  */
 class BlogTag extends DataObject implements CategorisationObject
 {
@@ -44,8 +45,8 @@ class BlogTag extends DataObject implements CategorisationObject
     /**
      * @var array
      */
-    private static $has_one = [
-        'Blog' => Blog::class
+    private static $indexes = [
+        'URLSegment' => true,
     ];
 
     /**

--- a/src/Model/BlogTag.php
+++ b/src/Model/BlogTag.php
@@ -57,6 +57,11 @@ class BlogTag extends DataObject implements CategorisationObject
     ];
 
     /**
+     * @var string
+     */
+    private static $default_sort = '"BlogTag"."Title" ASC';
+
+    /**
      * {@inheritdoc}
      */
     protected function getListUrlSegment()

--- a/src/Model/CategorisationObject.php
+++ b/src/Model/CategorisationObject.php
@@ -9,5 +9,10 @@ use SilverStripe\ORM\ManyManyList;
  */
 interface CategorisationObject
 {
-
+    /**
+     * Number of times this object has blog posts in the current blog
+     *
+     * @return int
+     */
+    public function getBlogCount();
 }

--- a/src/Model/CategorisationObject.php
+++ b/src/Model/CategorisationObject.php
@@ -2,8 +2,10 @@
 
 namespace SilverStripe\Blog\Model;
 
+use SilverStripe\ORM\ManyManyList;
+
 /**
- * @method ManyManyList BlogPosts
+ * @method ManyManyList|BlogPost[] BlogPosts()
  */
 interface CategorisationObject
 {

--- a/src/Tasks/FixBlogDuplicatesTask.php
+++ b/src/Tasks/FixBlogDuplicatesTask.php
@@ -108,7 +108,8 @@ class FixBlogDuplicatesTask extends BuildTask
             $title = $duplicate['Title'];
             $id = $duplicate['UseID'];
 
-            DB::prepared_query(<<<SQL
+            DB::prepared_query(
+                <<<SQL
 UPDATE "{$mappingTable}"
 INNER JOIN "{$itemTable}" ON "{$mappingTable}"."{$relationField}" = "{$itemTable}"."ID"
 SET "{$mappingTable}"."{$relationField}" = ? 

--- a/src/Tasks/FixBlogDuplicatesTask.php
+++ b/src/Tasks/FixBlogDuplicatesTask.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace SilverStripe\Blog\Tasks;
+
+use SilverStripe\Blog\Model\BlogCategory;
+use SilverStripe\Blog\Model\BlogTag;
+use SilverStripe\Control\Director;
+use SilverStripe\Core\Convert;
+use SilverStripe\Dev\BuildTask;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
+use SilverStripe\ORM\Queries\SQLSelect;
+use SilverStripe\View\HTML;
+
+class FixBlogDuplicatesTask extends BuildTask
+{
+    private static $segment = 'FixBlogDuplicatesTask';
+
+    protected $title = 'Fix blog duplicate categories / tags';
+
+    protected $description = 'Merge categories and tags with the same title';
+
+    public function run($request)
+    {
+        $this->dedupe(BlogTag::class, 'BlogPost_Tags', 'BlogTagID');
+        $this->dedupe(BlogCategory::class, 'BlogPost_Categories', 'BlogCategoryID');
+    }
+
+    /**
+     * Log message to console / page
+     *
+     * @param string $message
+     */
+    protected function message($message)
+    {
+        if (Director::is_cli()) {
+            echo "{$message}\n";
+        } else {
+            echo HTML::createTag('p', [], Convert::raw2xml($message));
+        }
+    }
+
+    /**
+     * Progress used for CLI output
+     *
+     * @var int
+     */
+    protected $printedDots = 0;
+
+    /**
+     * Render progress dots (20 dots per column)
+     *
+     * @param        $current
+     * @param int    $total
+     * @param string $character
+     */
+    protected function progress($current, $total = 0, $character = '.')
+    {
+        if (!Director::is_cli()) {
+            return;
+        }
+        while ($this->printedDots < $current) {
+            echo $character;
+            $this->printedDots++;
+            if ($this->printedDots % 80 === 0) {
+                if ($total) {
+                    $len = strlen($total);
+                    echo str_pad("{$this->printedDots}/{$total}", $len * 2 + 2, ' ', STR_PAD_LEFT);
+                }
+                echo "\n";
+            }
+        }
+    }
+
+    /**
+     * Deduplicate the given class
+     *
+     * @param string $class         Class name to dedupe
+     * @param string $mappingTable  Table name mapping
+     * @param string $relationField Name of foreign key relation field on mapping table
+     */
+    protected function dedupe($class, $mappingTable, $relationField)
+    {
+        $this->printedDots = 0;
+
+        // Find all duplicates
+        $itemTable = DataObject::getSchema()->tableName($class);
+        $duplicates = SQLSelect::create()
+            ->setSelect([
+                'Title' => '"Title"',
+                'Count' => 'COUNT(*)',
+                'UseID' => 'MIN("ID")',
+            ])
+            ->setFrom($itemTable)
+            ->setGroupBy('"Title"')
+            ->setHaving('"Count" > 1');
+
+        $count = $duplicates->count();
+
+        $this->message("Found {$count} items with duplicates for type {$class}");
+
+        if (!$count) {
+            return;
+        }
+
+        $done = 0;
+        foreach ($duplicates->execute() as $duplicate) {
+            $title = $duplicate['Title'];
+            $id = $duplicate['UseID'];
+
+            DB::prepared_query(<<<SQL
+UPDATE "{$mappingTable}"
+INNER JOIN "{$itemTable}" ON "{$mappingTable}"."{$relationField}" = "{$itemTable}"."ID"
+SET "{$mappingTable}"."{$relationField}" = ? 
+WHERE "{$itemTable}"."Title" = ? 
+SQL
+                ,
+                [$id, $title]
+            );
+
+            // Delete duplicates
+            $duplicateItems = DataObject::get($class)->filter([
+                'Title'  => $title,
+                'ID:not' => $id,
+            ]);
+            /** @var DataObject $duplicateItem */
+            foreach ($duplicateItems as $duplicateItem) {
+                $duplicateItem->delete();
+            }
+
+            // Update progress bar
+            $done++;
+            $this->progress($done, $count);
+        }
+
+        $this->progress("");
+        $this->progress("Completed cleaning duplicates for {$class}");
+    }
+}

--- a/tests/BlogTagTest.php
+++ b/tests/BlogTagTest.php
@@ -61,14 +61,15 @@ class BlogTagTest extends FunctionalTest
      */
     public function testAllowMultibyteUrlSegment()
     {
+        /** @var Blog $blog */
         $blog = $this->objFromFixture(Blog::class, 'FirstBlog');
         $tag = new BlogTag();
-        $tag->BlogID = $blog->ID;
+        $tag->setBlogID($blog->ID);
         $tag->Title = 'تست';
         $tag->write();
         // urlencoded
         $this->assertEquals('%D8%AA%D8%B3%D8%AA', $tag->URLSegment);
-        $link = Controller::join_links($tag->Blog()->Link(), 'tag', '%D8%AA%D8%B3%D8%AA');
+        $link = Controller::join_links($blog->Link(), 'tag', '%D8%AA%D8%B3%D8%AA');
         $this->assertEquals($link, $tag->getLink());
     }
 

--- a/tests/BlogTagTest.php
+++ b/tests/BlogTagTest.php
@@ -82,15 +82,19 @@ class BlogTagTest extends FunctionalTest
         $admin = $this->objFromFixture(Member::class, 'Admin');
         $editor = $this->objFromFixture(Member::class, 'Editor');
 
-        $tag = $this->objFromFixture(BlogTag::class, 'FirstTag');
+        /** @var Blog $firstBlog */
+        $firstBlog = $this->objFromFixture(Blog::class, 'FirstBlog');
+        $firstTag = $firstBlog->Tags(false)->find('URLSegment', 'first-tag');
 
-        $this->assertTrue($tag->canView($admin), 'Admin should be able to view tag.');
-        $this->assertTrue($tag->canView($editor), 'Editor should be able to view tag.');
+        $this->assertTrue($firstTag->canView($admin), 'Admin should be able to view tag.');
+        $this->assertTrue($firstTag->canView($editor), 'Editor should be able to view tag.');
 
-        $tag = $this->objFromFixture(BlogTag::class, 'SecondTag');
+        /** @var Blog $secondBlog */
+        $secondBlog = $this->objFromFixture(Blog::class, 'SecondBlog');
+        $secondTag = $secondBlog->Tags(false)->find('URLSegment', 'second-tag');
 
-        $this->assertTrue($tag->canView($admin), 'Admin should be able to view tag.');
-        $this->assertFalse($tag->canView($editor), 'Editor should not be able to view tag.');
+        $this->assertTrue($secondTag->canView($admin), 'Admin should be able to view tag.');
+        $this->assertFalse($secondTag->canView($editor), 'Editor should not be able to view tag.');
     }
 
     public function testCanEdit()
@@ -100,20 +104,26 @@ class BlogTagTest extends FunctionalTest
         $admin = $this->objFromFixture(Member::class, 'Admin');
         $editor = $this->objFromFixture(Member::class, 'Editor');
 
-        $tag = $this->objFromFixture(BlogTag::class, 'FirstTag');
+        /** @var Blog $firstBlog */
+        $firstBlog = $this->objFromFixture(Blog::class, 'FirstBlog');
+        $firstTag = $firstBlog->Tags(false)->find('URLSegment', 'first-tag');
 
-        $this->assertTrue($tag->canEdit($admin), 'Admin should be able to edit tag.');
-        $this->assertTrue($tag->canEdit($editor), 'Editor should be able to edit tag.');
+        $this->assertTrue($firstTag->canEdit($admin), 'Admin should be able to edit tag.');
+        $this->assertTrue($firstTag->canEdit($editor), 'Editor should be able to edit tag.');
 
-        $tag = $this->objFromFixture(BlogTag::class, 'SecondTag');
+        /** @var Blog $secondBlog */
+        $secondBlog = $this->objFromFixture(Blog::class, 'SecondBlog');
+        $secondTag = $secondBlog->Tags(false)->find('URLSegment', 'second-tag');
 
-        $this->assertTrue($tag->canEdit($admin), 'Admin should be able to edit tag.');
-        $this->assertFalse($tag->canEdit($editor), 'Editor should not be able to edit tag.');
+        $this->assertTrue($secondTag->canEdit($admin), 'Admin should be able to edit tag.');
+        $this->assertFalse($secondTag->canEdit($editor), 'Editor should not be able to edit tag.');
 
-        $tag = $this->objFromFixture(BlogTag::class, 'ThirdTag');
+        /** @var Blog $thirdBlog */
+        $thirdBlog = $this->objFromFixture(Blog::class, 'ThirdBlog');
+        $thirdTag = $thirdBlog->Tags(false)->find('URLSegment', 'third-tag');
 
-        $this->assertTrue($tag->canEdit($admin), 'Admin should always be able to edit tags.');
-        $this->assertTrue($tag->canEdit($editor), 'Editor should be able to edit tag.');
+        $this->assertTrue($thirdTag->canEdit($admin), 'Admin should always be able to edit tags.');
+        $this->assertTrue($thirdTag->canEdit($editor), 'Editor should be able to edit tag.');
     }
 
     public function testCanCreate()
@@ -136,20 +146,26 @@ class BlogTagTest extends FunctionalTest
         $admin = $this->objFromFixture(Member::class, 'Admin');
         $editor = $this->objFromFixture(Member::class, 'Editor');
 
-        $tag = $this->objFromFixture(BlogTag::class, 'FirstTag');
+        /** @var Blog $firstBlog */
+        $firstBlog = $this->objFromFixture(Blog::class, 'FirstBlog');
+        $firstTag = $firstBlog->Tags(false)->find('URLSegment', 'first-tag');
 
-        $this->assertTrue($tag->canDelete($admin), 'Admin should be able to delete tag.');
-        $this->assertTrue($tag->canDelete($editor), 'Editor should be able to delete tag.');
+        $this->assertTrue($firstTag->canDelete($admin), 'Admin should be able to delete tag.');
+        $this->assertTrue($firstTag->canDelete($editor), 'Editor should be able to delete tag.');
 
-        $tag = $this->objFromFixture(BlogTag::class, 'SecondTag');
+        /** @var Blog $secondBlog */
+        $secondBlog = $this->objFromFixture(Blog::class, 'SecondBlog');
+        $secondTag = $secondBlog->Tags(false)->find('URLSegment', 'second-tag');
 
-        $this->assertTrue($tag->canDelete($admin), 'Admin should be able to delete tag.');
-        $this->assertFalse($tag->canDelete($editor), 'Editor should not be able to delete tag.');
+        $this->assertTrue($secondTag->canDelete($admin), 'Admin should be able to delete tag.');
+        $this->assertFalse($secondTag->canDelete($editor), 'Editor should not be able to delete tag.');
 
-        $tag = $this->objFromFixture(BlogTag::class, 'ThirdTag');
+        /** @var Blog $thirdBlog */
+        $thirdBlog = $this->objFromFixture(Blog::class, 'ThirdBlog');
+        $thirdTag = $thirdBlog->Tags(false)->find('URLSegment', 'third-tag');
 
-        $this->assertTrue($tag->canDelete($admin), 'Admin should always be able to delete tags.');
-        $this->assertTrue($tag->canDelete($editor), 'Editor should be able to delete tag.');
+        $this->assertTrue($thirdTag->canDelete($admin), 'Admin should always be able to delete tags.');
+        $this->assertTrue($thirdTag->canDelete($editor), 'Editor should be able to delete tag.');
     }
 
     public function testDuplicateTagsForURLSegment()

--- a/tests/Model/BlogControllerFunctionalTest.yml
+++ b/tests/Model/BlogControllerFunctionalTest.yml
@@ -12,10 +12,6 @@ SilverStripe\Blog\Model\Blog:
   blog_a:
     URLSegment: my-blog
     Title: My Blog
-    Categories:
-      - =>SilverStripe\Blog\Model\BlogCategory.category_a
-    Tags:
-      - =>SilverStripe\Blog\Model\BlogTag.tag_a
 
 SilverStripe\Blog\Model\BlogPost:
   blogpost_a:
@@ -23,7 +19,3 @@ SilverStripe\Blog\Model\BlogPost:
     URLSegment: آبیدآبید
     PublishDate: 2017-08-01 00:00:00
     Parent: =>SilverStripe\Blog\Model\Blog.blog_a
-    Categories:
-      - =>SilverStripe\Blog\Model\BlogCategory.category_a
-    Tags:
-      - =>SilverStripe\Blog\Model\BlogTag.tag_a

--- a/tests/blog.yml
+++ b/tests/blog.yml
@@ -93,47 +93,37 @@ SilverStripe\Blog\Model\BlogCategory:
   FirstCategory:
     Title: 'First Category'
     URLSegment: 'first-category'
-    BlogID: =>SilverStripe\Blog\Model\Blog.FirstBlog
   SecondCategory:
     Title: 'Second Category'
     URLSegment: 'second-category'
-    BlogID: =>SilverStripe\Blog\Model\Blog.SecondBlog
   ThirdCategory:
     Title: 'Third Category'
     URLSegment: 'third-category'
-    BlogID: =>SilverStripe\Blog\Model\Blog.ThirdBlog
 
 SilverStripe\Blog\Model\BlogTag:
   FirstTag:
     Title: 'First Tag'
     URLSegment: 'first-tag'
-    BlogID: =>SilverStripe\Blog\Model\Blog.FirstBlog
   SecondTag:
     Title: 'Second Tag'
     URLSegment: 'second-tag'
-    BlogID: =>SilverStripe\Blog\Model\Blog.SecondBlog
   ThirdTag:
     Title: 'Third Tag'
     URLSegment: 'third-tag'
-    BlogID: =>SilverStripe\Blog\Model\Blog.ThirdBlog
 
   #Tags for Tag Cloud widget
   PopularTag:
     Title: 'Popular'
     URLSegment: 'popular'
-    BlogID: =>SilverStripe\Blog\Model\Blog.FourthBlog
   CoolTag:
     Title: 'Cool'
     URLSegment: 'cool'
-    BlogID: =>SilverStripe\Blog\Model\Blog.FourthBlog
   CatTag:
     Title: 'Cat'
     URLSegment: 'cat'
-    BlogID: =>SilverStripe\Blog\Model\Blog.FourthBlog
   KiwiTag:
     Title: 'Kiwi'
     URLSegment: 'kiwi'
-    BlogID: =>SilverStripe\Blog\Model\Blog.FourthBlog
 
 SilverStripe\Blog\Model\BlogPost:
   FirstBlogPost:


### PR DESCRIPTION
Initial implementation of #593 

This PR decouples tags and categories from blogs. When querying tags or categories for any blog, it will filter based on items that belong to current articles for that blog, rather than a distinct BlogID on each.

This prevents duplication of tags / categories (multiple blogs can share the same tag), and resolves a common data inconsistency where articles may be moved between blogs, but remain against tags / categories matching the "old" blog.

It also prevents issues with orphaned tags / categories (belonging to no blog at all).

Example inconsistency https://github.com/silverstripe/silverstripe-blog/issues/546

Next step is to build a task that de-duplicates tags / categories.

