### PR TITLE
Add missing widget models to db classname remapping

### DIFF
--- a/_config/legacy.yml
+++ b/_config/legacy.yml
@@ -7,3 +7,8 @@ SilverStripe\ORM\DatabaseAdmin:
     BlogCategory: SilverStripe\Blog\Model\BlogCategory
     BlogPost: SilverStripe\Blog\Model\BlogPost
     BlogTag: SilverStripe\Blog\Model\BlogTag
+    BlogArchiveWidget: SilverStripe\Blog\Widgets\BlogArchiveWidget
+    BlogCategoriesWidget: SilverStripe\Blog\Widgets\BlogCategoriesWidget
+    BlogRecentPostsWidget: SilverStripe\Blog\Widgets\BlogRecentPostsWidget
+    BlogTagsCloudWidget: SilverStripe\Blog\Widgets\BlogTagsCloudWidget
+    BlogTagsWidget: SilverStripe\Blog\Widgets\BlogTagsWidget


### PR DESCRIPTION
SilverStripe 4 has introduced namespacing, and thus ClassName field in
the database is now referring to classes that no longer exist. However
on a dev/build these will be updated so long as there is configuration
mapping the old class name to the new class name. However Blog module
here is missing the widget classes, which causes problems with
migrations. This will fix that.