### PR TITLE
Fix BlogPost canEdit permissions.

### DIFF
--- a/src/Model/BlogPost.php
+++ b/src/Model/BlogPost.php
@@ -564,8 +564,8 @@ class BlogPost extends Page
     {
         $member = $this->getMember($member);
 
-        if (parent::canEdit($member)) {
-            return true;
+        if (!parent::canEdit($member)) {
+            return false;
         }
 
         $parent = $this->Parent();


### PR DESCRIPTION
resolves #607
If permissions earlier in the inheritance chain fail, we should not allow users to edit posts.
If permissions earlier in the inheritance chain succeed, we should still go through the checks in this method.