### PR TITLE
FIX: augmentLoadLazyFields doesn't work with renamed tables

### DIFF
--- a/src/Model/BlogPostFilter.php
+++ b/src/Model/BlogPostFilter.php
@@ -57,9 +57,10 @@ class BlogPostFilter extends DataExtension
      */
     public function augmentLoadLazyFields(SQLSelect &$query, DataQuery &$dataQuery = null, $dataObject)
     {
+        $blogPostTable = DataObject::getSchema()->tableName(BlogPost::class);
         $dataQuery->innerJoin(
-            DataObject::getSchema()->tableName(BlogPost::class),
-            '"SiteTree"."ID" = "BlogPost"."ID"'
+            $blogPostTable,
+            '"SiteTree"."ID" = "' . $blogPostTable . '"."ID"'
         );
     }
 }


### PR DESCRIPTION
On a project I renamed the table BlogPosts to News_Posts which led to a broken join clause.