### PR TITLE
Using Advanced Workflows - If Blog post is in Workflow, Admin can still publish page breaking the workflow

### DIFF
--- a/src/Model/BlogPost.php
+++ b/src/Model/BlogPost.php
@@ -528,14 +528,14 @@ class BlogPost extends Page
     {
         $member = $this->getMember($member);
 
-        if (Permission::checkMember($member, 'ADMIN')) {
-            return true;
-        }
-
         $extended = $this->extendedCan('canPublish', $member);
 
         if ($extended !== null) {
             return $extended;
+        }
+        
+        if (Permission::checkMember($member, 'ADMIN')) {
+            return true;
         }
 
         $parent = $this->Parent();


### PR DESCRIPTION
If you are utilizing the Advanced Workflows module using a simply review and approve process the following happens on all pages except blog posts currently.

1. Content author creates a 'Page' type page class and requests approval to publish
2. Admin is notified and must select 'reject' or 'approve', the publish button is hidden.  Screen shot below of how page normally looks for the admin -

![Screen Shot 2020-10-23 at 11 07 19 AM](https://user-images.githubusercontent.com/443120/97027137-f09e2e80-151f-11eb-9720-0405ec54537b.png)

Now if we do the same with a blog post

1. Content Author creates a new 'Blog Post' type page class under a blog, requests approval to publish
2. Admin is notified and must select 'reject' or 'approve', the publish button is shown but should not be shown due to workflow being active.  Screen shot below -

![Screen Shot 2020-10-23 at 11 09 19 AM](https://user-images.githubusercontent.com/443120/97027350-378c2400-1520-11eb-8583-92117ed95521.png)

The cause for this is that the blog posts canPublish function was checking for an administrator account before letting the Advanced Workflow extensions run first.  I have changed the order and now this is working as expected.

