### PR TITLE
Ensure pagination start is not a negative number

### DIFF
--- a/src/Model/BlogController.php
+++ b/src/Model/BlogController.php
@@ -457,7 +457,7 @@ class BlogController extends PageController
         $posts->setPageLength($pageSize);
 
         // Set current page
-        $start = (int)$this->request->getVar($posts->getPaginationGetVar());
+        $start = max(0, (int)$this->request->getVar($posts->getPaginationGetVar()));
         $posts->setPageStart($start);
 
         return $posts;


### PR DESCRIPTION
If a user tries to access a negative start page such as `/blog?start=-10` this triggers a server error. This is because the code will pass this negative start to the limit function, which throws the error.

> [Emergency] Uncaught InvalidArgumentException: SQLSelect::setLimit() only takes positive values

This problem affects any Silverstripe website with a blog.

This code change should fix the issue.