### PR TITLE
Only lazy load categories dropdown if there is a large number of categories

### DIFF
--- a/src/Model/BlogPost.php
+++ b/src/Model/BlogPost.php
@@ -312,6 +312,11 @@ class BlogPost extends Page
                 );
             }
 
+            $shouldLazyLoadCategories = true;
+            if($this->Categories()->count() < 15) {
+                $shouldLazyLoadCategories = false;
+            }
+
             // Get categories and tags
             // @todo: Reimplement the sidebar
             // $options = BlogAdminSidebar::create(
@@ -326,7 +331,7 @@ class BlogPost extends Page
                         $this->Categories()
                     )
                         ->setCanCreate($this->canCreateCategories())
-                        ->setShouldLazyLoad(true),
+                        ->setShouldLazyLoad($shouldLazyLoadCategories),
                     TagField::create(
                         'Tags',
                         _t(__CLASS__ . '.Tags', 'Tags'),


### PR DESCRIPTION
By lazy loading the dropdown, authors cannot see the list of existing categories to pick from and have to think of one from memory and start typing it.

This only sets the dropdown values to lazy load if there are more than 15 existing categories. 15 was chosen as this is also the number of categories that appear on one page of the Categories grid field.