### PR TITLE
Add index for `SiteTree` so that we prevent `index_merge` returning zero results

### DIFF
--- a/_config/indexes.yml
+++ b/_config/indexes.yml
@@ -1,0 +1,8 @@
+---
+Name: blogindexes
+---
+SilverStripe\CMS\Model\SiteTree:
+  indexes:
+    SiteTreeClassNameParentID:
+      - ClassName
+      - ParentID


### PR DESCRIPTION
This is a fix for a very strange issue that has been surfacing on Silverstripe Cloud platform.

It manifests as showing zero results when there are more than 3 `BlogPost`s on a given blog. 2 works just fine, as does 1, but three appears to be the magic number.

After a lot of weird debugging, I managed to narrow this down to MySQL using `index_merge` to retrieve the results of `BlogPost::get()->filter('ParentID', $this->ID)` - which returned inconsistent results. You can work around this by disabling `index_merge`, but that seemed like a bad idea, as it's the MySQL default.

Adding this index (which is the one that is ultimately generated by merging the two individual indexes) means that it doesn't have to create its own  "meta-index" and so the results are returned consistently.

I'm not _totally_ sure this works long-term (fix has only been in place a few days for each of the sites I've tested it on) but it has fixed multiple sites.