### PR TITLE
MNT Add github action for deploying userdocs

### DIFF
--- a/.github/workflows/deploy-userhelp-docs.yml
+++ b/.github/workflows/deploy-userhelp-docs.yml
@@ -1,0 +1,16 @@
+name: Deploy Userhelp Docs
+on:
+  push:
+    branches:
+      - '4'
+      - '3'
+      - '2'
+    paths:
+      - 'docs/en/userguide/**'
+jobs:
+  deploy:
+    name: deploy-userhelp-docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run build hook
+        run: curl -X POST -d {} https://api.netlify.com/build_hooks/${{ secrets.NETLIFY_BUILD_HOOK }}


### PR DESCRIPTION
- Set the branches that activate the action to match the ones used by userhelp according to [the userhelp sources json](https://github.com/silverstripe/doc.silverstripe.org/blob/master/sources-user.js)
- Clearly and accurately identify the specific action.

***NOTE:*** Do not merge this until someone confirms they have addd the `NETLIFY_BUILD_HOOK` secret to this repo.

## Parent issue
- https://github.com/silverstripe/doc.silverstripe.org/issues/246