### PR TITLE
Fixed type annotation

### DIFF
--- a/src/Model/BlogPost.php
+++ b/src/Model/BlogPost.php
@@ -35,7 +35,7 @@ use SilverStripe\View\Requirements;
  * @method ManyManyList Tags()
  * @method ManyManyList Authors()
  * @method Blog Parent()
- * @method Blog FeaturedImage()
+ * @method Image FeaturedImage()
  *
  * @property string $PublishDate
  * @property string $AuthorNames


### PR DESCRIPTION
`FeaturedImage()` returns an instance of `SilverStripe\Assets\Image`, not a `Blog`.