### PR TITLE
MNT Broken builds

### DIFF
--- a/src/Widgets/BlogTagsCloudWidget.php
+++ b/src/Widgets/BlogTagsCloudWidget.php
@@ -9,6 +9,7 @@ use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\Widgets\Model\Widget;
+use SilverStripe\Control\Controller;
 
 if (!class_exists(Widget::class)) {
     return;
@@ -98,7 +99,7 @@ class BlogTagsCloudWidget extends Widget
             foreach ($records as $record) {
                 $tag = DataObject::create();
                 $tag->TagName = $record['Title'];
-                $link = $bloglink.'tag/'.$record['URLSegment'];
+                $link = Controller::join_links($bloglink, 'tag', $record['URLSegment']);
                 $tag->Link = $link;
                 if ($record['TagCount'] > $maxTagCount) {
                     $maxTagCount = $record['TagCount'];


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/659

Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/3990680546/jobs/6844618201#step:12:69

`Failed asserting that two strings are equal. -'/fourth-blog/tag/cat' +'/fourth-blogtag/cat'`

Broken behat tests will be fixed as part of https://github.com/silverstripeltd/product-issues/issues/644