### PR TITLE
Bugfix: Updating BlogPostFilter::augmentSQL to make use of modern Versioned methods.

### DIFF
--- a/src/Model/BlogPostFilter.php
+++ b/src/Model/BlogPostFilter.php
@@ -28,13 +28,17 @@ class BlogPostFilter extends DataExtension
      */
     public function augmentSQL(SQLSelect $query, DataQuery $dataQuery = null)
     {
-        $stage = Versioned::get_stage();
 
         if (Controller::has_curr() && Controller::curr() instanceof LeftAndMain) {
             return;
         }
 
-        if ($stage == 'Live' || !Permission::check('VIEW_DRAFT_CONTENT')) {
+        if (Versioned::get_stage() === Versioned::LIVE ||
+            (
+                Versioned::get_draft_site_secured() &&
+                !Permission::check('VIEW_DRAFT_CONTENT')
+            )
+        ) {
             $query->addWhere(sprintf(
                 '"PublishDate" < \'%s\'',
                 Convert::raw2sql(DBDatetime::now())


### PR DESCRIPTION
This resolves a nuanced issue with some modules that rely upon get_draft_site_secured for draft previewing. 

For example, without this fix, on an app with [dnadesign/silverstripe-elemental](https://github.com/dnadesign/silverstripe-elemental) and [silverstripe/silverstripe-sharedraftcontent](https://github.com/silverstripe/silverstripe-sharedraftcontent), a preview of a draft blog whose PublishDate is null or in the past works as expected, but if the PublishDate is in the future, none of the elemental elements will be visible in the preview.  An update to BlogPostFilter is the only way to resolve the issue, and this fix serves to do just that.

This can be accepted into the `3.*` base as a bugfix then safely merged into `4.*` as well.

Editing my source branch is enabled for maintainers.

Fixes:

1. https://github.com/silverstripe/silverstripe-sharedraftcontent/issues/112 
2. https://github.com/silverstripe/silverstripe-sharedraftcontent/issues/155

Attn: @muskie9 