### PR TITLE
Remove broken icons from gridfield add button

### DIFF
--- a/src/Forms/GridField/GridFieldAddByDBField.php
+++ b/src/Forms/GridField/GridFieldAddByDBField.php
@@ -226,7 +226,6 @@ class GridFieldAddByDBField implements GridField_ActionProvider, GridField_HTMLP
             'add',
             'add'
         );
-        $addAction->setAttribute('data-icon', 'add');
         $addAction->addExtraClass('btn btn-primary');
 
         $forTemplate = ArrayData::create([]);


### PR DESCRIPTION
From icon data attribute from grid field add button.

## Issue
- #735 