### PR TITLE
Changed BlogProfileImage publish from onBeforeWrite to $owns

### DIFF
--- a/src/Model/BlogMemberExtension.php
+++ b/src/Model/BlogMemberExtension.php
@@ -35,6 +35,10 @@ class BlogMemberExtension extends DataExtension
         'BlogProfileImage' => Image::class
     ];
 
+    private static array $owns = [
+        'BlogProfileImage',
+    ];
+
     /**
      * @var array
      */
@@ -58,11 +62,6 @@ class BlogMemberExtension extends DataExtension
         while (!$this->validURLSegment()) {
             $this->owner->URLSegment = preg_replace('/-[0-9]+$/', '', $this->owner->URLSegment ?? '') . '-' . $count;
             $count++;
-        }
-
-        // Auto publish profile images
-        if ($this->owner->BlogProfileImage() && $this->owner->BlogProfileImage()->exists()) {
-            $this->owner->BlogProfileImage()->publishSingle();
         }
     }
 


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->

_Redo of #749_
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Due to the order in `onBeforeWrite`, the `BlogProfileImage` added in `BlogMemberExtension` doesn't get automatically published unless you have also changed the member's name (unlikely).

This is because if `FirstName` or `Surname` are unchanged, then `onBeforeWrite` returns, before being able to publish the profile image.

This PR sets it to use `$owns` to take care of publishing the image instead. 

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->
1. Create a new user in Security.
2. Click **Create**
3. **Upload** a new "Blog profile image" for the user.
4. Click **Save**

**What I expect to happen:** The image gets published.
**What actually happens:** The image stays as "Draft".

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #748

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
