### PR TITLE
ENH Auto-scaffold blog categories and tags formfields

### DIFF
--- a/src/Model/BlogTag.php
+++ b/src/Model/BlogTag.php
@@ -2,7 +2,10 @@
 
 namespace SilverStripe\Blog\Model;
 
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Forms\FormField;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\TagField\TagField;
 
 /**
  * A blog tag for keyword descriptions of a blog post.
@@ -54,6 +57,44 @@ class BlogTag extends DataObject implements CategorisationObject
     private static $belongs_many_many = [
         'BlogPosts' => BlogPost::class
     ];
+
+    public function scaffoldFormFieldForHasMany(
+        string $relationName,
+        ?string $fieldTitle,
+        DataObject $ownerRecord,
+        bool &$includeInOwnTab
+    ): FormField {
+        $includeInOwnTab = false;
+        return $this->scaffoldFormFieldForManyRelation($relationName, $fieldTitle, $ownerRecord);
+    }
+
+    public function scaffoldFormFieldForManyMany(
+        string $relationName,
+        ?string $fieldTitle,
+        DataObject $ownerRecord,
+        bool &$includeInOwnTab
+    ): FormField {
+        $includeInOwnTab = false;
+        return $this->scaffoldFormFieldForManyRelation($relationName, $fieldTitle, $ownerRecord);
+    }
+
+    private function scaffoldFormFieldForManyRelation(
+        string $relationName,
+        ?string $fieldTitle,
+        DataObject $ownerRecord
+    ): FormField {
+        $parent = ($ownerRecord instanceof SiteTree) ? $ownerRecord->Parent() : null;
+        $field = TagField::create(
+            $relationName,
+            _t($ownerRecord->ClassName . '.' . $relationName, $fieldTitle),
+            ($parent instanceof Blog) ? $parent->Tags() : static::get(),
+            $ownerRecord->$relationName()
+        )->setShouldLazyLoad(true);
+        if ($ownerRecord instanceof BlogPost) {
+            $field->setCanCreate($ownerRecord->canCreateTags());
+        }
+        return $field;
+    }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
See post-implementation note in the linked issue about these - short version is that this mirrors the implementation used in `BlogPost`, but I can't update `BlogPost` to take advantage of it just yet. That'll be handled in a separate issue.

## Issue
- https://github.com/silverstripe/.github/issues/262