### PR TITLE
MNT resolve translation lint failures

### DIFF
--- a/src/Model/BlogObject.php
+++ b/src/Model/BlogObject.php
@@ -41,7 +41,7 @@ trait BlogObject
             'Root',
             Tab::create(
                 'Main',
-                TextField::create('Title', _t(__CLASS__ . '.Title', 'Title'))
+                TextField::create('Title', $this->fieldLabel('Title'))
             )
         );
 

--- a/src/Widgets/BlogArchiveWidget.php
+++ b/src/Widgets/BlogArchiveWidget.php
@@ -85,6 +85,7 @@ class BlogArchiveWidget extends Widget
             $type = $archiveType->enumValues();
 
             foreach ($type as $k => $v) {
+                /** @phpstan-ignore translation.key (we need the key to be dynamic here) */
                 $type[$k] = _t(__CLASS__ .'.' . ucfirst(strtolower($v ?? '')), $v);
             }
 


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-blog/actions/runs/10278309181/job/28441784949
> Can't determine value of first argument to _t(). Use a simpler value. 

## Issue
- https://github.com/silverstripe/.github/issues/290