### PR TITLE
Fix blog plural en.yml

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -39,10 +39,10 @@ en:
     PERMISSIONS_CATEGORY: 'Blog permissions'
     PERMISSION_MANAGE_USERS_DESCRIPTION: 'Manage users for individual blogs'
     PERMISSION_MANAGE_USERS_HELP: 'Allow assignment of Editors, Writers, or Contributors to blogs'
-    PLURALNAME: 'Base Pages'
+    PLURALNAME: 'Blogs'
     PLURALS:
       one: 'A Blog'
-      other: '{count} Base Pages'
+      other: '{count} Blogs'
     Posted: Posted
     PostedIn: 'Posted in'
     PostsByUser: 'Posts by {firstname} {surname} for {title}'
@@ -90,10 +90,10 @@ en:
     CUSTOMSUMMARY: 'Add A Custom Summary'
     Categories: Categories
     FeaturedImage: 'Featured Image'
-    PLURALNAME: 'Base Pages'
+    PLURALNAME: 'Blog Posts'
     PLURALS:
       one: 'A Blog Post'
-      other: '{count} Base Pages'
+      other: '{count} Blog Posts'
     PageTitleLabel: 'Post Title'
     PostOptions: 'Post Options'
     PublishDate: 'Publish Date'


### PR DESCRIPTION
The English plural names for blog and blog post are incorrect. This fixes it up.