### PR TITLE
DEP Add conflict with lumberjack 4.0.0-alpha1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "silverstripe/standards": "^1",
         "phpstan/extension-installer": "^1.3"
     },
+    "conflict": {
+        "silverstripe/lumberjack": "4.0.0-alpha1"
+    },
     "extra": {
         "expose": [
             "client/dist",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/349

Fixes failing behat test https://github.com/silverstripe/silverstripe-blog/actions/runs/12385947917/job/34623704017#step:12:161

In silverstripe.log there is an error `line 57 {"exception":"[object] (BadMethodCallException(code: 0): Object->__call(): the method 'currentPageID' does not exist on 'SilverStripe\\CMS\\Controllers\\CMSPageEditController' at /home/runner/work/silverstripe-blog/silverstripe-blog/vendor/silverstripe/framework/src/Core/CustomMethods.php:57)"}`

That happens because lumberjack 4.0.0-alpha1 is being installed. This PR blocks that from installing so that 4.0.x-dev installs instead