### PR TITLE
FIX #606, correct URL for categories if Blog is on /home

### DIFF
--- a/src/Model/BlogObject.php
+++ b/src/Model/BlogObject.php
@@ -82,11 +82,10 @@ trait BlogObject
      */
     public function getLink()
     {
-        return Controller::join_links(
-            $this->Blog()->Link(),
+        return $this->Blog()->Link(Controller::join_links(
             $this->getListUrlSegment(),
             $this->URLSegment
-        );
+        ));
     }
 
     /**

--- a/tests/php/BlogCategoryTest.php
+++ b/tests/php/BlogCategoryTest.php
@@ -167,4 +167,34 @@ class BlogCategoryTest extends FunctionalTest
             $this->assertEquals(BlogTag::DUPLICATE_EXCEPTION, $messages[0]['messageType']);
         }
     }
+
+    /**
+     * @see https://github.com/silverstripe/silverstripe-blog/issues/606
+     */
+    public function testGetLink()
+    {
+        // Test normal blog location
+        $blog = $this->objFromFixture(Blog::class, 'FirstBlog');
+        $cat = new BlogCategory();
+        $cat->BlogID = $blog->ID;
+        $cat->Title = 'Test Category';
+        $cat->write();
+
+        $expectedLink = '/first-blog/category/test-category';
+        $this->assertEquals($expectedLink, $cat->getLink());
+
+        // Test homepage blog location
+        $homeBlog = new Blog();
+        $homeBlog->Title = 'Home Blog';
+        $homeBlog->URLSegment = 'home';
+        $homeBlog->write();
+
+        $homeCat = new BlogCategory();
+        $homeCat->BlogID = $homeBlog->ID;
+        $homeCat->Title = 'Home Category';
+        $homeCat->write();
+
+        $expectedHomeLink = '/home/category/home-category';
+        $this->assertEquals($expectedHomeLink, $homeCat->getLink());
+    }
 }


### PR DESCRIPTION
## Description
Get correct URL for categories if Blog is on `/home`. For categories `$this->Blog()->Link()` returns just `/` but should return `/home`.
## Manual testing steps
Create a Blog on `/home` and see categories fail
```
[User Warning] Request handler SilverStripe\CMS\Controllers\ModelAsController does not have a url_segment defined. Relying on this link may be an application error
GET /category/...

Line 573 in /var/www/html/vendor/silverstripe/framework/src/Control/RequestHandler.php
```
## Issues
- #606

## Pull request checklist

- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
