### PR TITLE
added translations (fixes #816)

### DIFF
--- a/src/Model/Blog.php
+++ b/src/Model/Blog.php
@@ -190,8 +190,7 @@ class Blog extends Page implements PermissionProvider
                     $tags
                 ]
             );
-
-            $fields->fieldByName('Root.Categorisation')
+            $fields->findTab('Root.Categorisation')
                 ->addExtraClass('blog-cms-categorisation')
                 ->setTitle(_t(__CLASS__ . '.Categorisation', 'Categorisation'));
         });
@@ -374,7 +373,7 @@ class Blog extends Page implements PermissionProvider
             '<a class="font-icon-info-circled toggle-description"></a>'
         );
 
-        $editorField = ListboxField::create('Editors', 'Editors', $members)
+        $editorField = ListboxField::create('Editors', $this->fieldLabel('Editors'), $members)
             ->setRightTitle($toggleButton)
             ->setDescription(
                 _t(
@@ -394,7 +393,7 @@ class Blog extends Page implements PermissionProvider
         if (!$this->canEditEditors()) {
             $editorField = $editorField->performDisabledTransformation();
         }
-        $writerField = ListboxField::create('Writers', 'Writers', $members)
+        $writerField = ListboxField::create('Writers', $this->fieldLabel('Writers'), $members)
             ->setRightTitle($toggleButton)
             ->setDescription(
                 _t(
@@ -414,7 +413,7 @@ class Blog extends Page implements PermissionProvider
             $writerField = $writerField->performDisabledTransformation();
         }
 
-        $contributorField = ListboxField::create('Contributors', 'Contributors', $members)
+        $contributorField = ListboxField::create('Contributors', $this->fieldLabel('Contributors'), $members)
             // ->setMultiple(true)
             ->setRightTitle($toggleButton)
             ->setDescription(
@@ -442,6 +441,8 @@ class Blog extends Page implements PermissionProvider
                 $contributorField
             ]
         );
+
+        $fields->findTab('Root.Users')->setTitle(_t(__CLASS__ . '.Users', 'Users'));
 
         return $fields;
     }


### PR DESCRIPTION
## Description
Added translations for labels and tab.

## Issues
#816 

## Question
I've used the `many_many_` keys from the yml-file. Not sure if this is allowed? Otherwise I will have to introduce some new translation keys. As for the tab-name, there I have used a new key. Should I add that to the en.yml?

## Pull request checklist
- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
